### PR TITLE
[server/middleware/casbin_rcba.go]: fix e.Enforce(sub, obj, act) multiple-value in single-value context bug

### DIFF
--- a/server/middleware/casbin_rcba.go
+++ b/server/middleware/casbin_rcba.go
@@ -5,6 +5,7 @@ import (
 	"gin-vue-admin/global/response"
 	"gin-vue-admin/model/request"
 	"gin-vue-admin/service"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -21,7 +22,8 @@ func CasbinHandler() gin.HandlerFunc {
 		sub := waitUse.AuthorityId
 		e := service.Casbin()
 		// 判断策略中是否存在
-		if global.GVA_CONFIG.System.Env == "develop" || e.Enforce(sub, obj, act) {
+		matchRes, _ := e.Enforce(sub, obj, act)
+		if global.GVA_CONFIG.System.Env == "develop" || matchRes {
 			c.Next()
 		} else {
 			response.Result(response.ERROR, gin.H{}, "权限不足", c)


### PR DESCRIPTION
1.  [casbin库](https://github.com/casbin/casbin/blob/master/enforcer.go) 中第60行Enforce(sub, obj, act) 是多返回值（bool,err) 

2.  [具体例子可参考官方库介绍页面GetStarted 第2点](https://github.com/casbin/casbin/tree/5281b5b3352da321646261a5a408a65aade0a7dc)
```golang
sub := "alice" // the user that wants to access a resource.
obj := "data1" // the resource that is going to be accessed.
act := "read" // the operation that the user performs on the resource.

if res := e.Enforce(sub, obj, act); res {
    // permit alice to read data1
} else {
    // deny the request, show an error
}
```


