### PR TITLE
README.md: use goproxy.cn instead gopm

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -115,14 +115,18 @@ go get -u github.com/swaggo/swag/cmd/swag
 ````
 
 ##### （2）无法翻墙
-由于国内没法安装 go.org/x 包下面的东西，需要先安装`gopm`
+由于国内没法安装 go.org/x 包下面的东西，推荐使用 [goproxy.cn](https://goproxy.cn/)
 
 ```bash
-# 下载gopm包
-go get -v -u github.com/gpmgo/gopm
+# 配置GOPROXY
+go env -w GO111MODULE=on
+go env -w GOPROXY=https://goproxy.cn,direct
+
+# get swag
+go get -g -v github.com/swaggo/swag/cmd/swag
 
 # 执行
-gopm get -g -v github.com/swaggo/swag/cmd/swag
+go get -g -v github.com/swaggo/swag/cmd/swag
 
 # 到GOPATH的/src/github.com/swaggo/swag/cmd/swag路径下执行
 go install

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -122,9 +122,6 @@ go get -u github.com/swaggo/swag/cmd/swag
 go env -w GO111MODULE=on
 go env -w GOPROXY=https://goproxy.cn,direct
 
-# get swag
-go get -g -v github.com/swaggo/swag/cmd/swag
-
 # 执行
 go get -g -v github.com/swaggo/swag/cmd/swag
 

--- a/README.md
+++ b/README.md
@@ -117,13 +117,14 @@ go get -u github.com/swaggo/swag/cmd/swag
 ````
 
 ##### (2) In mainland China 
-In mainland China, access to go.org/x is prohibited，we recommend `gopm`
+In mainland China, access to go.org/x is prohibited，we recommend [goproxy.cn](https://goproxy.cn/)
 ````bash
-# install gopm
-go get -v -u github.com/gpmgo/gopm
+# config GOPROXY
+go env -w GO111MODULE=on
+go env -w GOPROXY=https://goproxy.cn,direct
 
 # get swag
-gopm get -g -v github.com/swaggo/swag/cmd/swag
+go get -g -v github.com/swaggo/swag/cmd/swag
 
 # cd GOPATH/src/github.com/swaggo/swag/cmd/swag
 go install


### PR DESCRIPTION
In favor of Go Modules Proxy since Go 1.11, gopm has been archived and website (gopm.io) had be taken down.