### PR TITLE
打包静态文件到二进制

### DIFF
--- a/server/core/config.go
+++ b/server/core/config.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"gin-vue-admin/global"
+	_ "gin-vue-admin/packfile"
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/viper"
 )

--- a/server/packfile/notUsePackFile.go
+++ b/server/packfile/notUsePackFile.go
@@ -1,0 +1,3 @@
+// +build !packfile
+
+package packfile

--- a/server/packfile/usePackFile.go
+++ b/server/packfile/usePackFile.go
@@ -1,0 +1,45 @@
+// +build packfile
+
+package packfile
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+//go:generate go-bindata -o=staticFile.go -pkg=packfile -tags=packfile ../resource/... ../config.yaml
+
+func writeFile(path string, data []byte) {
+	// 如果文件夹不存在，预先创建文件夹
+	if lastSeparator := strings.LastIndex(path, "/"); lastSeparator != -1 {
+		dirPath := path[:lastSeparator]
+		if _, err := os.Stat(dirPath); err != nil && os.IsNotExist(err) {
+			os.MkdirAll(dirPath, os.ModePerm)
+		}
+	}
+
+	// 已存在的文件，不应该覆盖重写，可能在前端更改了配置文件等
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if err2 := ioutil.WriteFile(path, data, os.ModePerm); err2 != nil {
+			fmt.Printf("Write file failed: %s\n", path)
+		}
+	} else {
+		fmt.Printf("File exist, skip: %s\n", path)
+	}
+}
+
+func init() {
+	for key := range _bindata {
+		filePath, _ := filepath.Abs(strings.TrimPrefix(key, "."))
+		data, err := Asset(key)
+		if err != nil {
+			// Asset was not found.
+			fmt.Printf("Fail to find: %s\n", filePath)
+		} else {
+			writeFile(filePath, data)
+		}
+	}
+}


### PR DESCRIPTION
与当前默认方式不冲突  
使用方式
```bash
go get -u github.com/go-bindata/go-bindata/...
cd server
// 如果提示找不到go-bindata，请排查下 $GOPATH/bin 是否在环境变量中
go generate -tags=packfile ./packfile/usePackFile.go   
go build -tags=packfile
```
即可将该二进制文件放置到任何位置运行，不再需要`resource/...` `config.yaml`  
程序启动时，会将`go build`时存储到二进制中的快照，写入到当前目录对应位置。  

写入到磁盘的行为，只会在文件不存在时进行写入，不会覆盖。

本地简单测试无问题，如有问题我会进行`fix`。
