### PR TITLE
新增docker-compose的支持,文档说明取消gopm,改用Go Modules主流的代理模式

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -239,15 +239,16 @@ swag init
 > https://space.bilibili.com/322210472/channel/detail?cid=108884
 
 ## 8. 联系方式
+
 ### 8.1 技术群
 
-| QQ 群(满) | QQ 2群 |  
-|  :---:  |   :---:  |
-| <img src="http://qmplusimg.henrongyi.top/qq.jpg" width="180"/> |<img src="http://qmplusimg.henrongyi.top/qq2.png" width="180"/> |
+### QQ交流群：622360840
+| QQ 群(满) |
+|  :---:  |   
+| <img src="http://qmplusimg.henrongyi.top/qq.jpg" width="180"/> |
 
-### QQ交流群：622360840（满）
-### QQ交流2群：101809076
-### 微信交流群：可以添加上面任意一位开发者，备注"加入gin-vue-admin交流群"
+### 微信交流群
+可以添加上面任意一位开发者，备注"加入gin-vue-admin交流群"
 
 ### 8.2 项目组成员
 | 蒋 | 尹 | 严 | 杜 | 印 | 宋 |
@@ -258,7 +259,7 @@ swag init
 |  ----  | ----  | ----  |
 | [@piexlmax](https://github.com/piexlmax)  | 项目发起者 | 蒋 |
 | [@granty1](https://github.com/granty1)  | 后台开发 | 印 |
-| [@Ruio9244](https://github.com/Ruio9244)  | 全栈开发 | 严 |
+| [@Ruio9244](https://github.com/Ruio9244)  | 架构师 | 严 |
 | [@1319612909](https://github.com/1319612909)  | 前端UI开发 |  杜 |
 | [@krank666](https://github.com/krank666)  | 前端开发 | 尹 |
 | [@chen-chen-up](https://github.com/chen-chen-up)  | 新手开发 | 宋 |

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -240,11 +240,13 @@ swag init
 
 ## 8. 联系方式
 ### 8.1 技术群
-| QQ群 |  
-|  :---:  |
-| <img src="http://qmplusimg.henrongyi.top/qq.jpg" width="180"/> |
 
-### QQ交流群：622360840
+| QQ 群(满) | QQ 2群 |  
+|  :---:  |   :---:  |
+| <img src="http://qmplusimg.henrongyi.top/qq.jpg" width="180"/> |<img src="http://qmplusimg.henrongyi.top/qq2.png" width="180"/> |
+
+### QQ交流群：622360840（满）
+### QQ交流2群：101809076
 ### 微信交流群：可以添加上面任意一位开发者，备注"加入gin-vue-admin交流群"
 
 ### 8.2 项目组成员

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -66,8 +66,43 @@ Gin-vue-admin 的成长离不开大家的支持，如果你愿意为 gin-vue-adm
 
 - [gin-vue-admin_v1.0_dev](https://github.com/flipped-aurora/gin-vue-admin/tree/gin-vue-admin_v1_dev) （v1.0停止维护）
 
-
 ## 2. 使用说明
+
+> 使用docker-compose体验本项目
+
+- 安装 docker-compose [官方文档](https://docs.docker.com/compose/install/)
+    - ```shell script
+       # 在Linux安装
+       # 1.1 运行此命令以下载Docker Compose的当前稳定版本
+       sudo curl -L "https://github.com/docker/compose/releases/download/1.26.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+       # 1.2 将可执行权限应用于二进制文件
+       sudo chmod +x /usr/local/bin/docker-compose 
+      ```
+    - ```shell script
+       # 使用Python的pip安装 
+       pip3 install docker-compose -i https://pypi.tuna.tsinghua.edu.cn/simple
+      ```
+    - 使用 Docker Desktop 
+        - Windows: https://hub.docker.com/editions/community/docker-ce-desktop-windows
+        - Mac: https://hub.docker.com/editions/community/docker-ce-desktop-mac/
+
+- 使用git克隆本项目
+    - ```git
+        git clone https://github.com/flipped-aurora/gin-vue-admin.git
+      ```
+- 使用docker-compose up一键启动启动项目
+    - ```shell script
+      # 使用docker-compose启动四个容器
+      docker-compose up
+      # 如果您修改了某些配置选项,可以使用此命令重新打包镜像
+      docker-compose up --build
+      # 使用docker-compose 后台启动
+      docker-compose up -d
+      ```
+      
+    - web项目预览 [http://127.0.0.1:8888/admin](http://127.0.0.1:8888/admin)
+    
+    - swagger文档 [http://127.0.0.1:8888/swagger/index.html](http://127.0.0.1:8888/swagger/index.html)
 
 ```
 - node版本 > v8.6.0
@@ -115,14 +150,21 @@ go get -u github.com/swaggo/swag/cmd/swag
 ````
 
 ##### （2）无法翻墙
-由于国内没法安装 go.org/x 包下面的东西，需要先安装`gopm`
+由于国内没法安装 go.org/x 包下面的东西，推荐使用 [goproxy.io](https://goproxy.io/zh/)
 
 ```bash
-# 下载gopm包
-go get -v -u github.com/gpmgo/gopm
+如果您使用的 Go 版本是 1.13 及以上(推荐)
+# 启用 Go Modules 功能
+go env -w GO111MODULE=on 
+# 配置 GOPROXY 环境变量
+go env -w GOPROXY=https://goproxy.io,direct
+
+如果您使用的 Go 版本是 1.12 及以下
+go env -w GO111MODULE=on
+go env -w GOPROXY=https://goproxy.io
 
 # 执行
-gopm get -g -v github.com/swaggo/swag/cmd/swag
+go get -g -v github.com/swaggo/swag/cmd/swag
 
 # 到GOPATH的/src/github.com/swaggo/swag/cmd/swag路径下执行
 go install
@@ -243,8 +285,9 @@ swag init
 ### 8.1 技术群
 
 ### QQ交流群：622360840
-| QQ 群(满) |
-|  :---:  |   
+
+|                            QQ 群                             |
+| :----------------------------------------------------------: |
 | <img src="http://qmplusimg.henrongyi.top/qq.jpg" width="180"/> |
 
 ### 微信交流群

--- a/README.md
+++ b/README.md
@@ -244,6 +244,11 @@ backend code file: model\dnModel\api.go
 
 ## 8. Contacts
 ### 8.1 Groups
+
+| QQ group(full) | QQ group2 |  
+|  :---:  |   :---:  |
+| <img src="http://qmplusimg.henrongyi.top/qq.jpg" width="180"/> |<img src="http://qmplusimg.henrongyi.top/qq2.jpg" width="180"/> |
+
 ### QQ group: 622360840（full）
 ### QQ group2: 101809076
 

--- a/README.md
+++ b/README.md
@@ -245,10 +245,9 @@ backend code file: model\dnModel\api.go
 ## 8. Contacts
 ### 8.1 Groups
 
-| QQ group(full) | QQ group2 |  
-|  :---:  |   :---:  |
-| <img src="http://qmplusimg.henrongyi.top/qq.jpg" width="180"/> |<img src="http://qmplusimg.henrongyi.top/qq2.jpg" width="180"/> |
-
+| QQ group | 
+|  :---:  |  
+| <img src="http://qmplusimg.henrongyi.top/qq.jpg" width="180"/> |
 ### QQ group: 622360840（full）
 ### QQ group2: 101809076
 

--- a/README.md
+++ b/README.md
@@ -244,10 +244,8 @@ backend code file: model\dnModel\api.go
 
 ## 8. Contacts
 ### 8.1 Groups
-| QQ group |  
-|  :---:  |
-| <img src="http://qmplusimg.henrongyi.top/qq.jpg" width="180"/> |
-### QQ group: 622360840
+### QQ group: 622360840（full）
+### QQ group2: 101809076
 
 ### Wechat group: add anyone above, comment "加入gin-vue-admin交流群"
 

--- a/README.md
+++ b/README.md
@@ -244,14 +244,14 @@ backend code file: model\dnModel\api.go
 
 ## 8. Contacts
 ### 8.1 Groups
+#### QQ group: 622360840
 
 | QQ group | 
 |  :---:  |  
 | <img src="http://qmplusimg.henrongyi.top/qq.jpg" width="180"/> |
-### QQ group: 622360840（full）
-### QQ group2: 101809076
 
-### Wechat group: add anyone above, comment "加入gin-vue-admin交流群"
+
+#### Wechat group: add anyone above, comment "加入gin-vue-admin交流群"
 
 ### 8.2 Team members
 | Jiang | Yin | Yan | Du | Yin | Song |

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ backend code file: model\dnModel\api.go
 |  ----  | ----  | ----  |
 | [@piexlmax](https://github.com/piexlmax)  | Project sponsor | Jiang |
 | [@granty1](https://github.com/granty1)  | Backend developer | Yin |
-| [@Ruio9244](https://github.com/Ruio9244)  | Full-stack developer | Yan |
+| [@Ruio9244](https://github.com/Ruio9244)  | Architect | Yan |
 | [@1319612909](https://github.com/1319612909)  | UI developer |  Du |
 | [@krank666](https://github.com/krank666)  | Frontend developer | Yin |
 | [@chen-chen-up](https://github.com/chen-chen-up)  | Novice developer | Song |

--- a/README.md
+++ b/README.md
@@ -71,6 +71,43 @@ We are excited that you are interested in contributing to gin-vue-admin. Before 
 
 
 ## 2. Getting started
+
+> Use docker-compose to experience this project
+
+- Installation docker-compose [Official document](https://docs.docker.com/compose/install/)
+    - ```shell script
+       # Install on Linux
+       # 1.1 Run this command to download the current stable version of Docker Compose
+       sudo curl -L "https://github.com/docker/compose/releases/download/1.26.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+       # 1.2 Apply executable permissions to binary files
+       sudo chmod +x /usr/local/bin/docker-compose 
+      ```
+    - ```shell script
+       # Use Python's pip installation
+       pip3 install docker-compose -i https://pypi.tuna.tsinghua.edu.cn/simple
+      ```
+    - Use Docker Desktop 
+        - Windows: https://hub.docker.com/editions/community/docker-ce-desktop-windows
+        - Mac: https://hub.docker.com/editions/community/docker-ce-desktop-mac/
+
+- Use git to clone this project
+    - ```git
+        git clone https://github.com/flipped-aurora/gin-vue-admin.git
+      ```
+- Use docker-compose up to start the startup project with one click
+    - ```shell script
+      # Use docker-compose to start four containers
+      docker-compose up
+      # If you modify some configuration options, you can use this command to repackage the image
+      docker-compose up --build
+      # Use docker-compose to start in the background
+      docker-compose up -d
+      ```
+      
+    - Web project preview [http://127.0.0.1:8888/admin](http://127.0.0.1:8888/admin)
+    
+    - swagger APIs [http://127.0.0.1:8888/swagger/index.html](http://127.0.0.1:8888/swagger/index.html)
+
 ```
 - node version > v8.6.0
 - golang version >= v1.11
@@ -117,13 +154,22 @@ go get -u github.com/swaggo/swag/cmd/swag
 ````
 
 ##### (2) In mainland China 
-In mainland China, access to go.org/x is prohibited，we recommend `gopm`
+
+In mainland China, access to go.org/x is prohibited，we recommend [goproxy.io](https://goproxy.io/zh/)
+
 ````bash
-# install gopm
-go get -v -u github.com/gpmgo/gopm
+If you are using Go version 1.13 and above (recommended)
+# Enable Go Modules function
+go env -w GO111MODULE=on 
+# Configure GOPROXY environment variables
+go env -w GOPROXY=https://goproxy.io,direct
+
+If you are using Go version 1.12 and below
+go env -w GO111MODULE=on
+go env -w GOPROXY=https://goproxy.io
 
 # get swag
-gopm get -g -v github.com/swaggo/swag/cmd/swag
+go get -g -v github.com/swaggo/swag/cmd/swag
 
 # cd GOPATH/src/github.com/swaggo/swag/cmd/swag
 go install

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,32 @@
+version: "3.8"
+
+services:
+  server:
+    build:
+      context: ./
+      dockerfile: ./dockerfile_server
+    container_name: gva-server # 容器名
+    restart: always
+    ports:
+      - '8888:8888'
+    depends_on:
+      - mysql
+      - redis
+
+  mysql:
+    image: registry.cn-shanghai.aliyuncs.com/gva/gva-mysql:1.1
+    container_name: gva-mysql
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci #设置utf8字符集
+    restart: always
+    ports:
+      - "3306:3306"  # host物理直接映射端口为6606
+    environment:
+      MYSQL_ROOT_PASSWORD: "Aa@6447985" # root管理员用户密码
+
+  redis:
+    image: redis:6.0.6
+    container_name: gva-redis # 容器名
+    restart: always
+    ports:
+      - '6379:6379'
+

--- a/dockerfile_server
+++ b/dockerfile_server
@@ -1,0 +1,47 @@
+FROM node:12.16.1 as gva-web
+
+WORKDIR /gva_web/
+COPY web/ .
+RUN npm install -g cnpm --registry=https://registry.npm.taobao.org
+RUN cnpm install || npm install
+RUN npm run build
+
+FROM golang:alpine as gva-server
+
+ENV GO111MODULE=on
+ENV GOPROXY=https://goproxy.io,direct
+WORKDIR /go/src/gin-vue-admin
+COPY server/ ./
+RUN go env && go list && go build -o gva-server .
+
+
+FROM nginx:alpine
+LABEL MAINTAINER="SliverHorn"
+
+WORKDIR gva/
+
+# copy web
+COPY --from=gva-web /gva_web/dist ./resource/dist
+# copy server
+COPY --from=gva-server /go/src/gin-vue-admin/gva-server ./
+COPY --from=gva-server /go/src/gin-vue-admin/config.yaml ./
+COPY --from=gva-server /go/src/gin-vue-admin/resource ./resource
+
+
+EXPOSE 8888
+
+ENTRYPOINT ./gva-server
+
+# 根据Dockerfile生成Docker镜像
+
+# docker build -t gva-server:1.0 .
+
+#- 根据Docker镜像启动Docker容器
+#    - 后台运行
+#    - ```
+#    docker run -d -p 8888:8888 --name gva-server-v1 gva-server:1.0
+#      ```
+#    - 以可交互模式运行, Ctrl + p + q
+#    - ```
+#    docker run -it -p 8888:8888 --name gva-server-v1 gva-server:1.0
+#      ```

--- a/server/core/server.go
+++ b/server/core/server.go
@@ -18,6 +18,7 @@ func RunWindowsServer() {
 	}
 	Router := initialize.Routers()
 	Router.Static("/form-generator", "./resource/page")
+	Router.Static("/admin", "./resource/dist")
 
 	//InstallPlugs(Router)
 	// end 插件描述

--- a/web/.env.production
+++ b/web/.env.production
@@ -1,2 +1,2 @@
 ENV = 'production'
-VUE_APP_BASE_API = '/v1'
+VUE_APP_BASE_API = ''


### PR DESCRIPTION
1. README.md:更新docker-compose的使用方式,取消gopm,改用Go Modules主流的代理模式
2. README-zh_CN.md: 更新docker-compose的使用方式,取消gopm,改用Go Modules主流的代理模式
3. docker-compose.yaml: docker-compose的配置文件;[dockerfile_server]:定义web项目打包以及server项目打包,和以二进制文件4. 启动项目
5. server/config.yaml:修改redis的addr为redis:6379,修改mysql的path为mysql, 修改use-multipoint为true,修改是为了配合docker-compose使用
6. server/core/server.go:添加gin的静态文件托管代码
7. web/.env.production:取消v1的代理