### PR TITLE
cors.go: fix部分浏览器不支持*的格式

### DIFF
--- a/server/global/response/response.go
+++ b/server/global/response/response.go
@@ -1,8 +1,10 @@
 package response
 
 import (
+	"github.com/360EntSecGroup-Skylar/excelize"
 	"github.com/gin-gonic/gin"
 	"net/http"
+	"strconv"
 )
 
 type Response struct {
@@ -39,6 +41,20 @@ func OkWithData(data interface{}, c *gin.Context) {
 
 func OkDetailed(data interface{}, message string, c *gin.Context) {
 	Result(SUCCESS, data, message, c)
+}
+
+func OkWithXlsx(list []interface{}, title []string, fileName string, c *gin.Context) {
+	file := excelize.NewFile()
+	file.SetSheetRow("Sheet1", "A1", &title)
+	for i, v := range list {
+		// 第一行被title占用
+		lint := strconv.Itoa(i + 2)
+		file.SetSheetRow("Sheet1", "A"+lint, v)
+	}
+	c.Header("Content-Type", "application/octet-stream")
+	c.Header("Content-Disposition", "attachment; filename="+fileName)
+	c.Header("Content-Transfer-Encoding", "binary")
+	_ = file.Write(c.Writer)
 }
 
 func Fail(c *gin.Context) {

--- a/server/go.mod
+++ b/server/go.mod
@@ -3,6 +3,7 @@ module gin-vue-admin
 go 1.12
 
 require (
+	github.com/360EntSecGroup-Skylar/excelize v1.4.1 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/casbin/casbin v1.9.1
 	github.com/casbin/casbin/v2 v2.11.0

--- a/server/middleware/cors.go
+++ b/server/middleware/cors.go
@@ -9,7 +9,8 @@ import (
 func Cors() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		method := c.Request.Method
-		c.Header("Access-Control-Allow-Origin", "*")
+		origin := c.Request.Header.Get("Origin")
+		c.Header("Access-Control-Allow-Origin", origin)
 		c.Header("Access-Control-Allow-Headers", "Content-Type,AccessToken,X-CSRF-Token, Authorization, Token,X-Token,X-User-Id\"")
 		c.Header("Access-Control-Allow-Methods", "POST, GET, OPTIONS,DELETE,PUT")
 		c.Header("Access-Control-Expose-Headers", "Content-Length, Access-Control-Allow-Origin, Access-Control-Allow-Headers, Content-Type")


### PR DESCRIPTION
safari, 360 IE10以下的浏览器不支持*, origin的获取改为从header中获取