### PR TITLE
自定义logger保留gorm的格式输出控制台, 修改SetUserInfo的校验规则为IdVerify

### DIFF
--- a/server/api/v1/sys_user.go
+++ b/server/api/v1/sys_user.go
@@ -240,7 +240,7 @@ func DeleteUser(c *gin.Context) {
 func SetUserInfo(c *gin.Context) {
 	var user model.SysUser
 	_ = c.ShouldBindJSON(&user)
-	if err := utils.Verify(user, utils.SetUserVerify); err != nil {
+	if err := utils.Verify(user, utils.IdVerify); err != nil {
 		response.FailWithMessage(err.Error(), c)
 		return
 	}

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -60,7 +60,7 @@ mysql:
   max-idle-conns: 10
   max-open-conns: 100
   log-mode: false
-  log-zap: false
+  log-zap: ""
 
 # local configuration
 local:

--- a/server/config/gorm.go
+++ b/server/config/gorm.go
@@ -9,5 +9,5 @@ type Mysql struct {
 	MaxIdleConns int    `mapstructure:"max-idle-conns" json:"maxIdleConns" yaml:"max-idle-conns"`
 	MaxOpenConns int    `mapstructure:"max-open-conns" json:"maxOpenConns" yaml:"max-open-conns"`
 	LogMode      bool   `mapstructure:"log-mode" json:"logMode" yaml:"log-mode"`
-	LogZap       bool   `mapstructure:"log-zap" json:"logZap" yaml:"log-zap"`
+	LogZap       string `mapstructure:"log-zap" json:"logZap" yaml:"log-zap"`
 }

--- a/server/initialize/gorm.go
+++ b/server/initialize/gorm.go
@@ -10,7 +10,11 @@ import (
 	"os"
 )
 
-// Gorm 初始化数据库并产生数据库全局变量
+//@author: SliverHorn
+//@function: Gorm
+//@description: 初始化数据库并产生数据库全局变量
+//@return: *gorm.DB
+
 func Gorm() *gorm.DB {
 	switch global.GVA_CONFIG.System.DbType {
 	case "mysql":
@@ -20,7 +24,12 @@ func Gorm() *gorm.DB {
 	}
 }
 
-// MysqlTables 注册数据库表专用
+// MysqlTables
+//@author: SliverHorn
+//@function: MysqlTables
+//@description: 注册数据库表专用
+//@param: db *gorm.DB
+
 func MysqlTables(db *gorm.DB) {
 	err := db.AutoMigrate(
 		model.SysUser{},
@@ -52,7 +61,12 @@ func MysqlTables(db *gorm.DB) {
 	global.GVA_LOG.Info("register table success")
 }
 
-// GormMysql 初始化Mysql数据库
+//
+//@author: SliverHorn
+//@function: GormMysql
+//@description: 初始化Mysql数据库
+//@return: *gorm.DB
+
 func GormMysql() *gorm.DB {
 	m := global.GVA_CONFIG.Mysql
 	dsn := m.Username + ":" + m.Password + "@tcp(" + m.Path + ")/" + m.Dbname + "?" + m.Config
@@ -76,23 +90,45 @@ func GormMysql() *gorm.DB {
 	}
 }
 
-// gormConfig 根据配置决定是否开启日志
+//@author: SliverHorn
+//@function: gormConfig
+//@description: 根据配置决定是否开启日志
+//@param: mod bool
+//@return: *gorm.Config
+
 func gormConfig(mod bool) *gorm.Config {
-	if global.GVA_CONFIG.Mysql.LogZap {
+	switch global.GVA_CONFIG.Mysql.LogZap {
+	case "Silent":
+		return &gorm.Config{
+			Logger:                                   Default.LogMode(logger.Silent),
+			DisableForeignKeyConstraintWhenMigrating: true,
+		}
+	case "Error":
+		return &gorm.Config{
+			Logger:                                   Default.LogMode(logger.Error),
+			DisableForeignKeyConstraintWhenMigrating: true,
+		}
+	case "Warn":
+		return &gorm.Config{
+			Logger:                                   Default.LogMode(logger.Warn),
+			DisableForeignKeyConstraintWhenMigrating: true,
+		}
+	case "Info":
 		return &gorm.Config{
 			Logger:                                   Default.LogMode(logger.Info),
 			DisableForeignKeyConstraintWhenMigrating: true,
 		}
-	}
-	if mod {
-		return &gorm.Config{
-			Logger:                                   logger.Default.LogMode(logger.Info),
-			DisableForeignKeyConstraintWhenMigrating: true,
-		}
-	} else {
-		return &gorm.Config{
-			Logger:                                   logger.Default.LogMode(logger.Silent),
-			DisableForeignKeyConstraintWhenMigrating: true,
+	default:
+		if mod {
+			return &gorm.Config{
+				Logger:                                   logger.Default.LogMode(logger.Info),
+				DisableForeignKeyConstraintWhenMigrating: true,
+			}
+		} else {
+			return &gorm.Config{
+				Logger:                                   logger.Default.LogMode(logger.Silent),
+				DisableForeignKeyConstraintWhenMigrating: true,
+			}
 		}
 	}
 }

--- a/server/utils/verify.go
+++ b/server/utils/verify.go
@@ -6,12 +6,10 @@ var (
 	MenuVerify             = Rules{"Path": {NotEmpty()}, "ParentId": {NotEmpty()}, "Name": {NotEmpty()}, "Component": {NotEmpty()}, "Sort": {Ge("0")}}
 	MenuMetaVerify         = Rules{"Title": {NotEmpty()}}
 	LoginVerify            = Rules{"CaptchaId": {NotEmpty()}, "Captcha": {NotEmpty()}, "Username": {NotEmpty()}, "Password": {NotEmpty()}}
-	SetUserVerify          = Rules{"ID": {NotEmpty()}, "Username": {NotEmpty()}, "NickName": {NotEmpty()}, "HeaderImg": {NotEmpty()}}
 	RegisterVerify         = Rules{"Username": {NotEmpty()}, "NickName": {NotEmpty()}, "Password": {NotEmpty()}, "AuthorityId": {NotEmpty()}}
 	PageInfoVerify         = Rules{"Page": {NotEmpty()}, "PageSize": {NotEmpty()}}
 	CustomerVerify         = Rules{"CustomerName": {NotEmpty()}, "CustomerPhoneData": {NotEmpty()}}
 	AutoCodeVerify         = Rules{"Abbreviation": {NotEmpty()}, "StructName": {NotEmpty()}, "PackageName": {NotEmpty()}, "Fields": {NotEmpty()}}
-	WorkFlowVerify         = Rules{"WorkflowNickName": {NotEmpty()}, "WorkflowName": {NotEmpty()}, "WorkflowDescription": {NotEmpty()}, "WorkflowStepInfo": {NotEmpty()}}
 	AuthorityVerify        = Rules{"AuthorityId": {NotEmpty()}, "AuthorityName": {NotEmpty()}, "ParentId": {NotEmpty()}}
 	AuthorityIdVerify      = Rules{"AuthorityId": {NotEmpty()}}
 	OldAuthorityVerify     = Rules{"OldAuthorityId": {NotEmpty()}}


### PR DESCRIPTION
- 修改文件：
server/initialize/gorm.go
server/config/gorm.go
server/config.yaml
server/utils/verify.go
server/api/v1/sys_user.go
- 功能实现：
自定义logger保留gorm的格式输出控制台, 修改SetUserInfo的校验规则为IdVerify
- 实现功能说明：
自定义gorm的logger所需要的接口，使用全局zap自定义打印规则,实现日志可以通过zap记录入本地log文件里
- 注意事项
`config.yaml` 中 `mysql` 下的 `log-zap` 的值为 `"Silent"` , `"Error"`, `"Warn"`, `"Info"`
```yaml
# mysql connect configuration
mysql:
  path: '127.0.0.1:3306'
  config: 'charset=utf8mb4&parseTime=True&loc=Local'
  db-name: 'qmPlus'
  username: 'root'
  password: 'Aa@6447985'
  max-idle-conns: 10
  max-open-conns: 100
  log-mode: false
  log-zap: false
  log-zap: ""
```
gorm的sql日志记录使用`zap`持久化是使用`log-zap: false`, `log-zap: "Info"`