### PR TITLE
增加超级管理员自动添加API权限和菜单权限

### DIFF
--- a/server/service/sys_api.go
+++ b/server/service/sys_api.go
@@ -18,6 +18,17 @@ func CreateApi(api model.SysApi) (err error) {
 	if !errors.Is(global.GVA_DB.Where("path = ? AND method = ?", api.Path, api.Method).First(&model.SysApi{}).Error, gorm.ErrRecordNotFound) {
 		return errors.New("存在相同api")
 	}
+
+	err = global.GVA_DB.Create(&api).Error
+	// 如果没有错误则把菜单权限给管理员加上
+	if err == nil {
+		err = AddCasbin("1", request.CasbinInfo{
+			Method: api.Method,
+			Path:   api.Path,
+		})
+	}
+	return err
+
 	return global.GVA_DB.Create(&api).Error
 }
 

--- a/server/service/sys_api.go
+++ b/server/service/sys_api.go
@@ -22,12 +22,12 @@ func CreateApi(api model.SysApi) (err error) {
 	err = global.GVA_DB.Create(&api).Error
 	// 如果没有错误则把菜单权限给管理员加上
 	if err == nil {
-		err = AddCasbin("1", request.CasbinInfo{
+		// 这里无视错误信息
+		_ = AddCasbin("1", request.CasbinInfo{
 			Method: api.Method,
 			Path:   api.Path,
 		})
 	}
-	return err
 
 	return global.GVA_DB.Create(&api).Error
 }

--- a/server/service/sys_casbin.go
+++ b/server/service/sys_casbin.go
@@ -38,6 +38,24 @@ func UpdateCasbin(authorityId string, casbinInfos []request.CasbinInfo) error {
 	return nil
 }
 
+// 新增添加权限功能，用来给予超级管理员使用
+func AddCasbin(authorityId string, casbinInfo request.CasbinInfo) error {
+	rules := [][]string{}
+	cm := model.CasbinModel{
+		Ptype:       "p",
+		AuthorityId: authorityId,
+		Path:        casbinInfo.Path,
+		Method:      casbinInfo.Method,
+	}
+	rules = append(rules, []string{cm.AuthorityId, cm.Path, cm.Method})
+	e := Casbin()
+	success, _ := e.AddPolicies(rules)
+	if success == false {
+		return errors.New("存在相同api,添加失败,请联系管理员")
+	}
+	return nil
+}
+
 //@author: [piexlmax](https://github.com/piexlmax)
 //@function: UpdateCasbinApi
 //@description: API更新随动
@@ -57,7 +75,6 @@ func UpdateCasbinApi(oldPath string, newPath string, oldMethod string, newMethod
 //@description: 获取权限列表
 //@param: authorityId string
 //@return: pathMaps []request.CasbinInfo
-
 
 func GetPolicyPathByAuthorityId(authorityId string) (pathMaps []request.CasbinInfo) {
 	e := Casbin()

--- a/server/service/sys_menu.go
+++ b/server/service/sys_menu.go
@@ -94,6 +94,14 @@ func AddBaseMenu(menu model.SysBaseMenu) (err error) {
 		err = errors.New("存在重复name，请修改name")
 	}
 	err = global.GVA_DB.Create(&menu).Error
+
+	// 如果没有错误则把菜单权限给超级管理员加上
+	if err == nil {
+		global.GVA_DB.Table("sys_authority_menus").Create([]map[string]interface{}{
+			{"sys_authority_authority_id": "1", "sys_base_menu_id": menu.ID},
+		})
+	}
+
 	return err
 }
 


### PR DESCRIPTION
1. 添加一个超级管理员角色（角色id固定为1）
2. 当后续添加API、菜单时，自动会添加相应权限到超级管理员角色上