### PR TITLE
+ 增加当添加API和菜单时自动给超级管理员添加权限（注意：请先添加一个超级管理员角色，角色id为1）

### DIFF
--- a/server/service/sys_api.go
+++ b/server/service/sys_api.go
@@ -18,7 +18,17 @@ func CreateApi(api model.SysApi) (err error) {
 	if !errors.Is(global.GVA_DB.Where("path = ? AND method = ?", api.Path, api.Method).First(&model.SysApi{}).Error, gorm.ErrRecordNotFound) {
 		return errors.New("存在相同api")
 	}
-	return global.GVA_DB.Create(&api).Error
+
+	err = global.GVA_DB.Create(&api).Error
+	// 如果没有错误则把菜单权限给管理员加上
+	if err == nil {
+		_ = AddCasbin("1", request.CasbinInfo{
+			Method: api.Method,
+			Path:   api.Path,
+		})
+	}
+
+	return err
 }
 
 //@author: [piexlmax](https://github.com/piexlmax)

--- a/server/service/sys_casbin.go
+++ b/server/service/sys_casbin.go
@@ -12,6 +12,24 @@ import (
 	"strings"
 )
 
+// 新增添加权限功能，用来给予超级管理员使用
+func AddCasbin(authorityId string, casbinInfo request.CasbinInfo) error {
+	rules := [][]string{}
+	cm := model.CasbinModel{
+		Ptype:       "p",
+		AuthorityId: authorityId,
+		Path:        casbinInfo.Path,
+		Method:      casbinInfo.Method,
+	}
+	rules = append(rules, []string{cm.AuthorityId, cm.Path, cm.Method})
+	e := Casbin()
+	success, _ := e.AddPolicies(rules)
+	if success == false {
+		return errors.New("存在相同api,添加失败,请联系管理员")
+	}
+	return nil
+}
+
 //@author: [piexlmax](https://github.com/piexlmax)
 //@function: UpdateCasbin
 //@description: 更新casbin权限
@@ -57,7 +75,6 @@ func UpdateCasbinApi(oldPath string, newPath string, oldMethod string, newMethod
 //@description: 获取权限列表
 //@param: authorityId string
 //@return: pathMaps []request.CasbinInfo
-
 
 func GetPolicyPathByAuthorityId(authorityId string) (pathMaps []request.CasbinInfo) {
 	e := Casbin()

--- a/server/service/sys_menu.go
+++ b/server/service/sys_menu.go
@@ -94,6 +94,14 @@ func AddBaseMenu(menu model.SysBaseMenu) (err error) {
 		err = errors.New("存在重复name，请修改name")
 	}
 	err = global.GVA_DB.Create(&menu).Error
+
+	// 如果没有错误则把菜单权限给超级管理员加上
+	if err == nil {
+		global.GVA_DB.Table("sys_authority_menus").Create([]map[string]interface{}{
+			{"sys_authority_authority_id": "1", "sys_base_menu_id": menu.ID},
+		})
+	}
+
 	return err
 }
 


### PR DESCRIPTION
使用方法：
1. 先添加一个角色：超级管理员，设置角色id为1
2. 添加API，自动加上权限
3. 添加菜单，自动加上权限