### PR TITLE
使用go1.16 embed打包静态文件

### DIFF
--- a/server/embed.go
+++ b/server/embed.go
@@ -1,0 +1,72 @@
+// +build go1.16
+
+package main
+
+import (
+	"embed"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+)
+
+//go:embed resource config.yaml
+var resource embed.FS
+
+func restoreFolder(dirPath string) {
+	fis, err := resource.ReadDir(dirPath)
+	if err != nil {
+		fmt.Println("[embed restore resource file] err:", err)
+		return
+	}
+	if _, err := os.Stat(dirPath); err != nil && os.IsNotExist(err) {
+		os.MkdirAll(dirPath, os.ModePerm)
+	}
+
+	for _, fi := range fis {
+		if !fi.IsDir() {
+			restoreFile(dirPath, fi)
+		} else {
+			newDirPath := ""
+			if dirPath != "." {
+				newDirPath = dirPath + "/" + fi.Name()
+			} else {
+				newDirPath = fi.Name()
+			}
+			restoreFolder(newDirPath)
+		}
+	}
+}
+
+func restoreFile(dirPath string, f fs.DirEntry) {
+	filePath := ""
+	if dirPath == "." {
+		filePath = f.Name()
+	} else {
+		filePath = dirPath + string(os.PathSeparator) + f.Name()
+	}
+
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		srcFile, err2 := resource.Open(filePath)
+		if err2 != nil {
+			fmt.Println("[embed restore resource file] err:", err2)
+			return
+		}
+
+		dstFile, err2 := os.Create(filePath)
+		if err2 != nil {
+			fmt.Println("[embed restore resource file] err:", err2)
+		}
+		if _, err2 = io.Copy(dstFile, srcFile); err2 != nil {
+			fmt.Printf("[embed restore resource file] write file failed: %s\n", dstFile)
+		}
+		srcFile.Close()
+		dstFile.Close()
+	} else {
+		fmt.Printf("[embed restore resource file] file exist, skip: %s\n", filePath)
+	}
+}
+
+func init() {
+	restoreFolder(".")
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module gin-vue-admin
 
-go 1.14
+go 1.16
 
 require (
 	github.com/360EntSecGroup-Skylar/excelize/v2 v2.3.2

--- a/server/packfile/notUsePackFile.go
+++ b/server/packfile/notUsePackFile.go
@@ -1,3 +1,3 @@
-// +build !packfile
+// +build !packfile go1.16
 
 package packfile

--- a/server/packfile/usePackFile.go
+++ b/server/packfile/usePackFile.go
@@ -1,4 +1,5 @@
 // +build packfile
+// +build !go1.16
 
 package packfile
 


### PR DESCRIPTION
使用go1.16新特性重构静态文件打包功能**预览版**~    
使用方式：本地升级go1.16版本
正常`go build` 即可

当前做了兼容，等正式升级go1.16版本后，可以删除原packfile文件夹。  
tmpl文件或许可以仅放在内存中，不进行恢复  

需要在windows上进行测试路径拼接符是否正确  

生成文件对比结果  
![image](https://user-images.githubusercontent.com/43537346/108535695-928b2780-7316-11eb-8759-ebead5f5f678.png)

当文件存在时不会进行覆盖
![image](https://user-images.githubusercontent.com/43537346/108535785-a6368e00-7316-11eb-93fc-6b12d2c92935.png)
