### PR TITLE
权限配置文件加载报错提示。

### DIFF
--- a/server/service/sys_casbin.go
+++ b/server/service/sys_casbin.go
@@ -93,8 +93,12 @@ func Casbin() *casbin.Enforcer {
 	admin := global.GVA_CONFIG.Mysql
 	a, _ := gormadapter.NewAdapter(global.GVA_CONFIG.System.DbType, admin.Username+":"+admin.Password+"@("+admin.Path+")/"+admin.Dbname, true)
 	e, _ := casbin.NewEnforcer(global.GVA_CONFIG.Casbin.ModelPath, a)
-	e.AddFunction("ParamsMatch", ParamsMatchFunc)
-	_ = e.LoadPolicy()
+	if e != nil {
+		e.AddFunction("ParamsMatch", ParamsMatchFunc)
+		_ = e.LoadPolicy()
+	} else {
+		global.GVA_LOG.Error("Casbin Error casbin权限配置文件加载错误")
+	}
 	return e
 }
 


### PR DESCRIPTION
部署服务器的时候，忘记上传resource目录，服务器就会有错误提示。