### PR TITLE
初始化数据增加,api自动注册到apis表,更新go.mod

### DIFF
--- a/server/config.yaml
+++ b/server/config.yaml
@@ -45,6 +45,7 @@ system:
   db-type: 'mysql'
   oss-type: 'local'    # 控制oss选择走本期还是 七牛等其他仓 自行增加其他oss仓可以在 server/utils/upload/upload.go 中 NewOss函数配置
   use-multipoint: false
+  auto-register-router: false
 
 # captcha configuration
 captcha:

--- a/server/config/system.go
+++ b/server/config/system.go
@@ -1,9 +1,10 @@
 package config
 
 type System struct {
-	Env           string `mapstructure:"env" json:"env" yaml:"env"`
-	Addr          int    `mapstructure:"addr" json:"addr" yaml:"addr"`
-	DbType        string `mapstructure:"db-type" json:"dbType" yaml:"db-type"`
-	OssType       string `mapstructure:"oss-type" json:"ossType" yaml:"oss-type"`
-	UseMultipoint bool   `mapstructure:"use-multipoint" json:"useMultipoint" yaml:"use-multipoint"`
+	Env                string `mapstructure:"env" json:"env" yaml:"env"`
+	Addr               int    `mapstructure:"addr" json:"addr" yaml:"addr"`
+	DbType             string `mapstructure:"db-type" json:"dbType" yaml:"db-type"`
+	OssType            string `mapstructure:"oss-type" json:"ossType" yaml:"oss-type"`
+	UseMultipoint      bool   `mapstructure:"use-multipoint" json:"useMultipoint" yaml:"use-multipoint"`
+	AutoRegisterRouter bool   `mapstructure:"auto-register-router" json:"auto-register-router" yaml:"auto-register-router"`
 }

--- a/server/core/server.go
+++ b/server/core/server.go
@@ -14,8 +14,7 @@ type server interface {
 }
 
 func RunWindowsServer() {
-	if global.GVA_CONFIG.System.UseMultipoint {
-		// 初始化redis服务
+	if global.GVA_CONFIG.System.UseMultipoint { // 初始化redis服务
 		initialize.Redis()
 	}
 	engine := initialize.Routers()
@@ -37,6 +36,10 @@ func RunWindowsServer() {
 	如果项目让您获得了收益，希望您能请团队喝杯可乐:https://www.gin-vue-admin.com/docs/coffee
 `, address)
 
-	go service.AutoRegisterRouter(engine)
+	if global.GVA_CONFIG.System.AutoRegisterRouter { // 自动把路由注册到sys_apis表
+		go func() {
+			_ = service.AutoRegisterRouter(engine)
+		}()
+	}
 	global.GVA_LOG.Error(s.ListenAndServe().Error())
 }

--- a/server/core/server.go
+++ b/server/core/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"gin-vue-admin/global"
 	"gin-vue-admin/initialize"
+	"gin-vue-admin/service"
 	"go.uber.org/zap"
 	"time"
 )
@@ -17,11 +18,11 @@ func RunWindowsServer() {
 		// 初始化redis服务
 		initialize.Redis()
 	}
-	Router := initialize.Routers()
-	Router.Static("/form-generator", "./resource/page")
+	engine := initialize.Routers()
+	engine.Static("/form-generator", "./resource/page")
 
 	address := fmt.Sprintf(":%d", global.GVA_CONFIG.System.Addr)
-	s := initServer(address, Router)
+	s := initServer(address, engine)
 	// 保证文本顺序输出
 	// In order to ensure that the text order output can be deleted
 	time.Sleep(10 * time.Microsecond)
@@ -35,5 +36,7 @@ func RunWindowsServer() {
 	默认前端文件运行地址:http://127.0.0.1:8080
 	如果项目让您获得了收益，希望您能请团队喝杯可乐:https://www.gin-vue-admin.com/docs/coffee
 `, address)
+
+	go service.AutoRegisterRouter(engine)
 	global.GVA_LOG.Error(s.ListenAndServe().Error())
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/lestrrat-go/file-rotatelogs v2.3.0+incompatible
 	github.com/lestrrat-go/strftime v1.0.3 // indirect
 	github.com/mailru/easyjson v0.7.1 // indirect
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.2.2 // indirect
 	github.com/mojocn/base64Captcha v1.3.1
 	github.com/onsi/ginkgo v1.7.0 // indirect
@@ -42,8 +41,8 @@ require (
 	github.com/shirou/gopsutil v3.21.1+incompatible
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
-	github.com/spf13/cobra v1.1.1
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.7.0
 	github.com/swaggo/gin-swagger v1.2.0
 	github.com/swaggo/swag v1.6.7

--- a/server/initialize/router.go
+++ b/server/initialize/router.go
@@ -4,7 +4,9 @@ import (
 	_ "gin-vue-admin/docs"
 	"gin-vue-admin/global"
 	"gin-vue-admin/middleware"
+	"gin-vue-admin/model/response"
 	"gin-vue-admin/router"
+	"gin-vue-admin/service"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -29,6 +31,13 @@ func Routers() *gin.Engine {
 	{
 		router.InitBaseRouter(PublicGroup) // 注册基础功能路由 不做鉴权
 		router.InitInitRouter(PublicGroup) // 自动初始化相关
+		PublicGroup.POST("/autoRegisterRouter", func(context *gin.Context) {
+			if err := service.AutoRegisterRouter(Router); err != nil {
+				response.FailWithMessage("自动把路由注册到sys_apis表 失败!", context)
+			} else {
+				response.Ok(context)
+			}
+		})
 	}
 	PrivateGroup := Router.Group("")
 	PrivateGroup.Use(middleware.JWTAuth()).Use(middleware.CasbinHandler())

--- a/server/service/sys_api.go
+++ b/server/service/sys_api.go
@@ -144,8 +144,8 @@ func DeleteApisByIds(ids request.IdsReq) error {
 }
 
 //@author: [SliverHorn](https://github.com/SliverHorn)
-//@function: DeleteApis
-//@description: 删除选中API
+//@function: AutoRegisterRouter
+//@description: 自动注册api到sys_apis表
 //@param: engine *gin.Engine
 //@return: error
 
@@ -198,12 +198,14 @@ func AutoRegisterRouter(engine *gin.Engine) {
 		} else if strings.Contains(path, "get") {
 			if list := strings.Split(path, "get"); len(list) == 2 {
 				if strings.Contains(list[1], "List") {
-					if lists := strings.Split(list[1], "List"); len(lists) == 1 {
+					if lists := strings.Split(list[1], "List"); len(lists) == 2 {
 						entity.Description = "获取" + lists[0] + "列表"
 					}
 				}
 				entity.Description = "获取" + list[1]
 			}
+		} else {
+			entity.Description = path // 如果不符合代码生成器规则, api中文描述则为路由路径
 		}
 		if err := global.GVA_DB.Create(&entity).Error; err != nil { // 创建api记录
 			global.GVA_LOG.Info("插入 sys_apis 表记录失败!", zap.String("Path", path), zap.String("method", method))

--- a/server/service/sys_api.go
+++ b/server/service/sys_api.go
@@ -145,11 +145,11 @@ func DeleteApisByIds(ids request.IdsReq) error {
 
 //@author: [SliverHorn](https://github.com/SliverHorn)
 //@function: AutoRegisterRouter
-//@description: 自动注册api到sys_apis表
+//@description: 自动把路由注册到sys_apis表
 //@param: engine *gin.Engine
 //@return: error
 
-func AutoRegisterRouter(engine *gin.Engine) {
+func AutoRegisterRouter(engine *gin.Engine) error {
 	routes := engine.Routes()
 	for i := 0; i < len(routes); i++ {
 		path := routes[i].Path
@@ -209,7 +209,8 @@ func AutoRegisterRouter(engine *gin.Engine) {
 		}
 		if err := global.GVA_DB.Create(&entity).Error; err != nil { // 创建api记录
 			global.GVA_LOG.Info("插入 sys_apis 表记录失败!", zap.String("Path", path), zap.String("method", method))
-			continue
+			return err
 		}
 	}
+	return nil
 }

--- a/server/source/api.go
+++ b/server/source/api.go
@@ -86,6 +86,11 @@ var apis = []model.SysApi{
 	{global.GVA_MODEL{ID: 83, CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/excel/exportExcel", "导出excel", "excel", "POST"},
 	{global.GVA_MODEL{ID: 84, CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/excel/downloadTemplate", "下载excel模板", "excel", "GET"},
 	{global.GVA_MODEL{ID: 85, CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/api/deleteApisByIds", "批量删除api", "api", "DELETE"},
+	{global.GVA_MODEL{ID: 86, CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/system/reloadSystem", "重启服务", "system", "POST"},
+	{global.GVA_MODEL{ID: 87, CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/fileUploadAndDownload/breakpointContinue", "断点续传", "breakpointContinue", "POST"},
+	{global.GVA_MODEL{ID: 88, CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/fileUploadAndDownload/breakpointContinueFinish", "断点续传完成", "breakpointContinue", "POST"},
+	{global.GVA_MODEL{ID: 89, CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/fileUploadAndDownload/removeChunk", "移除断点续传的分片记录", "breakpointContinue", "POST"},
+	{global.GVA_MODEL{ID: 90, CreatedAt: time.Now(), UpdatedAt: time.Now()}, "/fileUploadAndDownload/findFile", "根据ID获取File记录", "fileUploadAndDownload", "POST"},
 }
 
 
@@ -94,7 +99,7 @@ var apis = []model.SysApi{
 //@description: sys_apis 表数据初始化
 func (a *api) Init() error {
 	return global.GVA_DB.Transaction(func(tx *gorm.DB) error {
-		if tx.Where("id IN ?", []int{1, 67}).Find(&[]model.SysApi{}).RowsAffected == 2 {
+		if tx.Where("id IN ?", []int{1, 90}).Find(&[]model.SysApi{}).RowsAffected == 2 {
 			color.Danger.Println("\n[Mysql] --> sys_apis 表的初始数据已存在!")
 			return nil
 		}

--- a/server/source/casbin.go
+++ b/server/source/casbin.go
@@ -49,6 +49,7 @@ var carbines = []gormadapter.CasbinRule{
 	{PType: "p", V0: "888", V1: "/system/getSystemConfig", V2: "POST"},
 	{PType: "p", V0: "888", V1: "/system/setSystemConfig", V2: "POST"},
 	{PType: "p", V0: "888", V1: "/system/getServerInfo", V2: "POST"},
+	{PType: "p", V0: "888", V1: "/system/reloadSystem", V2: "POST"},
 	{PType: "p", V0: "888", V1: "/customer/customer", V2: "POST"},
 	{PType: "p", V0: "888", V1: "/customer/customer", V2: "PUT"},
 	{PType: "p", V0: "888", V1: "/customer/customer", V2: "DELETE"},
@@ -167,7 +168,7 @@ var carbines = []gormadapter.CasbinRule{
 func (c *casbin) Init() error {
 	global.GVA_DB.AutoMigrate(gormadapter.CasbinRule{})
 	return global.GVA_DB.Transaction(func(tx *gorm.DB) error {
-		if tx.Find(&[]gormadapter.CasbinRule{}).RowsAffected == 154 {
+		if tx.Find(&[]gormadapter.CasbinRule{}).RowsAffected == 148 {
 			color.Danger.Println("\n[Mysql] --> casbin_rule 表的初始数据已存在!")
 			return nil
 		}


### PR DESCRIPTION
功能： 
- 读取 gin 路由，通过与 `sys_apis` 表对比，把未注册的路由通过 `goroutine` 自动注册
- 开放`/autoRegisterRouter` 路由接口，方便前端调用
- `config.yaml` 添加一个开关，使用`go` 开启注册的子任务
- `sys_apis` 初始化记录新增
- `go.mod` 多余依赖去除

修改文件:
- `server/core/server.go`
- `server/config/system.go`
- `server/initialize/router.go`
- `server/source/api.go`
- `server/source/casbin.go`
- `server/service/sys_api.go`
- `server/go.mod`
- `server/config.yaml`