### PR TITLE
[修复阿里云OSS图片上传路径不一致错误]

### DIFF
--- a/server/config.yaml
+++ b/server/config.yaml
@@ -104,6 +104,7 @@ aliyun-oss:
   access-key-secret: 'yourAccessKeySecret'
   bucket-name: 'yourBucketName'
   bucket-url: 'yourBucketUrl'
+  base-path: 'yourBasePath'
 
 # tencent cos configuration
 tencent-cos:

--- a/server/config/oss.go
+++ b/server/config/oss.go
@@ -20,6 +20,7 @@ type AliyunOSS struct {
 	AccessKeySecret string `mapstructure:"access-key-secret" json:"accessKeySecret" yaml:"access-key-secret"`
 	BucketName      string `mapstructure:"bucket-name" json:"bucketName" yaml:"bucket-name"`
 	BucketUrl       string `mapstructure:"bucket-url" json:"bucketUrl" yaml:"bucket-url"`
+	BasePath 		string `mapstructure:"base-path" json:"basePath" yaml:"base-path"`
 }
 type TencentCOS struct {
 	Bucket     string `mapstructure:"bucket" json:"bucket" yaml:"bucket"`

--- a/server/utils/upload/aliyun_oss.go
+++ b/server/utils/upload/aliyun_oss.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"go.uber.org/zap"
 	"mime/multipart"
-	"path/filepath"
 	"time"
 )
 
@@ -27,7 +26,8 @@ func (*AliyunOSS) UploadFile(file *multipart.FileHeader) (string, string, error)
 	}
 	defer f.Close() // 创建文件 defer 关闭
 	// 上传阿里云路径 文件名格式 自己可以改 建议保证唯一性
-	yunFileTmpPath := filepath.Join("uploads", time.Now().Format("2006-01-02")) + "/" + file.Filename
+	//yunFileTmpPath := filepath.Join("uploads", time.Now().Format("2006-01-02")) + "/" + file.Filename
+	yunFileTmpPath := global.GVA_CONFIG.AliyunOSS.BasePath + "/" + "uploads" + "/" + time.Now().Format("2006-01-02") + "/" + file.Filename
 
 	// 上传文件流。
 	err = bucket.PutObject(yunFileTmpPath, f)

--- a/web/src/components/upload/image.vue
+++ b/web/src/components/upload/image.vue
@@ -17,7 +17,7 @@
       :before-upload="beforeImageUpload"
       :multiple="false"
     >
-      <img v-if="imageUrl" :src="path + imageUrl" class="image">
+      <img v-if="imageUrl" :src="imageUrl" class="image">
       <i v-else class="el-icon-plus image-uploader-icon" />
     </el-upload>
   </div>


### PR DESCRIPTION
- server端解决oss上传图片提交路径和存储路径不一致
- web端解决上传成功后封装的upload-image组件展示路径多加一个绝对路径后图片无法正常展示