### PR TITLE
添加gin-i18n

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.7.0
+	github.com/suisrc/gin-i18n v0.1.1 // indirect
 	github.com/swaggo/gin-swagger v1.2.0
 	github.com/swaggo/swag v1.6.7
 	github.com/tebeka/strftime v0.1.3 // indirect
@@ -51,6 +52,7 @@ require (
 	github.com/unrolled/secure v1.0.7
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
+	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/tools v0.0.0-20200324003944-a576cf524670 // indirect
 	google.golang.org/protobuf v1.24.0 // indirect
 	gopkg.in/ini.v1 v1.55.0 // indirect

--- a/server/initialize/router.go
+++ b/server/initialize/router.go
@@ -5,6 +5,8 @@ import (
 	"gin-vue-admin/global"
 	"gin-vue-admin/middleware"
 	"gin-vue-admin/router"
+	i18n "github.com/suisrc/gin-i18n"
+	"golang.org/x/text/language"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -24,6 +26,16 @@ func Routers() *gin.Engine {
 	global.GVA_LOG.Info("use middleware cors")
 	Router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	global.GVA_LOG.Info("register swagger handler")
+
+	//多语言初始化
+	bundle := i18n.NewBundle(
+		language.Chinese, //默认中文
+		"language/zh-CN.toml",
+		"language/en-US.toml",
+	)
+	Router.Use(i18n.Serve(bundle))
+	//多语言end
+
 	// 方便统一添加路由组前缀 多服务器上线使用
 	PublicGroup := Router.Group("")
 	{

--- a/server/language/en-US.toml
+++ b/server/language/en-US.toml
@@ -1,0 +1,2 @@
+do-success = "success"
+do-failed = "failed"

--- a/server/language/zh-CN.toml
+++ b/server/language/zh-CN.toml
@@ -1,0 +1,2 @@
+do-success = "操作成功"
+do-failed = "操作失败"

--- a/server/model/response/response.go
+++ b/server/model/response/response.go
@@ -2,6 +2,7 @@ package response
 
 import (
 	"github.com/gin-gonic/gin"
+	i18n "github.com/suisrc/gin-i18n"
 	"net/http"
 )
 
@@ -18,15 +19,16 @@ const (
 
 func Result(code int, data interface{}, msg string, c *gin.Context) {
 	// 开始时间
+	text := i18n.FormatText(c, &i18n.Message{ID: msg, Other: msg})
 	c.JSON(http.StatusOK, Response{
 		code,
 		data,
-		msg,
+		text,
 	})
 }
 
 func Ok(c *gin.Context) {
-	Result(SUCCESS, map[string]interface{}{}, "操作成功", c)
+	Result(SUCCESS, map[string]interface{}{}, "do-success", c)
 }
 
 func OkWithMessage(message string, c *gin.Context) {
@@ -34,7 +36,7 @@ func OkWithMessage(message string, c *gin.Context) {
 }
 
 func OkWithData(data interface{}, c *gin.Context) {
-	Result(SUCCESS, data, "操作成功", c)
+	Result(SUCCESS, data, "do-success", c)
 }
 
 func OkWithDetailed(data interface{}, message string, c *gin.Context) {
@@ -42,7 +44,7 @@ func OkWithDetailed(data interface{}, message string, c *gin.Context) {
 }
 
 func Fail(c *gin.Context) {
-	Result(ERROR, map[string]interface{}{}, "操作失败", c)
+	Result(ERROR, map[string]interface{}{}, "do-failed", c)
 }
 
 func FailWithMessage(message string, c *gin.Context) {


### PR DESCRIPTION
新增功能：使用github.com/suisrc/gin-i18n，支持接口多语言。
server/go.mod
server/initialize/router.go: 多语言初始化
server/language: 语言包
server/model/response/response.go: 返回值修改，默认返回与修改前一致
使用方式：添加lang参数：?lang=zh-CN  |  ?lang=en-US