### PR TITLE
bug修复：jwt黑名单启动时候未加载及未生效

### DIFF
--- a/server/core/viper.go
+++ b/server/core/viper.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/flipped-aurora/gin-vue-admin/server/service/system"
-
 	"github.com/songzhibin97/gkit/cache/local_cache"
 
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
@@ -61,9 +59,6 @@ func Viper(path ...string) *viper.Viper {
 	global.GVA_CONFIG.AutoCode.Root, _ = filepath.Abs("..")
 	global.BlackCache = local_cache.NewCache(
 		local_cache.SetDefaultExpire(time.Duration(global.GVA_CONFIG.JWT.ExpiresTime)))
-	// 从db加载jwt数据
-	if global.GVA_DB != nil {
-		system.LoadAll()
-	}
+
 	return v
 }

--- a/server/main.go
+++ b/server/main.go
@@ -4,6 +4,7 @@ import (
 	"github.com/flipped-aurora/gin-vue-admin/server/core"
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/initialize"
+	"github.com/flipped-aurora/gin-vue-admin/server/service/system"
 )
 
 //go:generate go env -w GO111MODULE=on
@@ -28,6 +29,10 @@ func main() {
 		// 程序结束前关闭数据库链接
 		db, _ := global.GVA_DB.DB()
 		defer db.Close()
+	}
+	// 从db加载jwt数据
+	if global.GVA_DB != nil {
+		system.LoadAll()
 	}
 	core.RunWindowsServer()
 }

--- a/server/service/system/jwt_black_list.go
+++ b/server/service/system/jwt_black_list.go
@@ -2,8 +2,9 @@ package system
 
 import (
 	"context"
-	"go.uber.org/zap"
 	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/system"
@@ -23,7 +24,7 @@ func (jwtService *JwtService) JsonInBlacklist(jwtList system.JwtBlacklist) (err 
 	if err != nil {
 		return
 	}
-	global.BlackCache.SetDefault(jwtList.Jwt, struct{}{})
+	global.BlackCache.SetNoExpire(jwtList.Jwt, struct{}{})
 	return
 }
 
@@ -73,6 +74,6 @@ func LoadAll() {
 		return
 	}
 	for i := 0; i < len(data); i++ {
-		global.BlackCache.SetDefault(data[i], struct{}{})
+		global.BlackCache.SetNoExpire(data[i], struct{}{})
 	} // jwt黑名单 加入 BlackCache 中
 }


### PR DESCRIPTION
1.viper加载时global.GVA_DB 还未初始化，无法从数据库加载jwt黑名单数据，所以把system.LoadAll()移动到main.go
2.gkit的local_cache SetDefault方法中，DefaultExpire固定为0，所以导致cache中的jwt黑名单只要一访问就会被删除从而导致jwt黑名单无效，所以改用SetNoExpire