### PR TITLE
bug修复：jwt黑名单启动时候未加载及未生效

### DIFF
--- a/server/core/server.go
+++ b/server/core/server.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/initialize"
+	"github.com/flipped-aurora/gin-vue-admin/server/service/system"
 	"go.uber.org/zap"
 )
 
@@ -18,6 +19,12 @@ func RunWindowsServer() {
 		// 初始化redis服务
 		initialize.Redis()
 	}
+
+	// 从db加载jwt数据
+	if global.GVA_DB != nil {
+		system.LoadAll()
+	}
+
 	Router := initialize.Routers()
 
 	Router.Static("/form-generator", "./resource/page")

--- a/server/core/viper.go
+++ b/server/core/viper.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/flipped-aurora/gin-vue-admin/server/service/system"
-
 	"github.com/songzhibin97/gkit/cache/local_cache"
 
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
@@ -61,9 +59,6 @@ func Viper(path ...string) *viper.Viper {
 	global.GVA_CONFIG.AutoCode.Root, _ = filepath.Abs("..")
 	global.BlackCache = local_cache.NewCache(
 		local_cache.SetDefaultExpire(time.Duration(global.GVA_CONFIG.JWT.ExpiresTime)))
-	// 从db加载jwt数据
-	if global.GVA_DB != nil {
-		system.LoadAll()
-	}
+
 	return v
 }


### PR DESCRIPTION
1.viper加载时global.GVA_DB 还未初始化，无法从数据库加载jwt黑名单数据，所以把system.LoadAll()移动到core/server.go中
2.gkit的local_cache SetDefault方法中，DefaultExpire固定为0（看源码应该是gkit的bug），所以导致cache中的jwt黑名单只要一访问就会被删除从而导致jwt黑名单无效，所以改用SetNoExpire