### PR TITLE
Update viper.go

### DIFF
--- a/server/core/viper.go
+++ b/server/core/viper.go
@@ -58,7 +58,7 @@ func Viper(path ...string) *viper.Viper {
 	}
 	global.GVA_CONFIG.AutoCode.Root, _ = filepath.Abs("..")
 	global.BlackCache = local_cache.NewCache(
-		local_cache.SetDefaultExpire(time.Second * time.Duration(global.GVA_CONFIG.JWT.ExpiresTime))
+		local_cache.SetDefaultExpire(time.Second * time.Duration(global.GVA_CONFIG.JWT.ExpiresTime)),
 		)
 	return v
 }


### PR DESCRIPTION
core/viper.go:61:95: syntax error: unexpected newline, expecting comma or )