### PR TITLE
修正生命周期钩子，将`beforeDestroy`更改为`beforeUnmount`

### DIFF
--- a/web/src/view/dashboard/dashbordCharts/echartsLine.vue
+++ b/web/src/view/dashboard/dashbordCharts/echartsLine.vue
@@ -51,7 +51,7 @@ export default {
       this.initChart()
     })
   },
-  beforeDestroy() {
+  beforeUnmount() {
     if (!this.chart) {
       return
     }

--- a/web/src/view/layout/aside/historyComponent/history.vue
+++ b/web/src/view/layout/aside/historyComponent/history.vue
@@ -120,7 +120,7 @@ export default {
     }
     this.setTab(this.$route)
   },
-  beforeDestroy() {
+  beforeUnmount() {
     emitter.off('collapse')
     emitter.off('mobile')
   },

--- a/web/src/view/layout/aside/index.vue
+++ b/web/src/view/layout/aside/index.vue
@@ -58,7 +58,7 @@ export default {
       this.isCollapse = item
     })
   },
-  beforeDestroy() {
+  beforeUnmount() {
     emitter.off('collapse')
   },
   methods: {

--- a/web/src/view/layout/screenfull/index.vue
+++ b/web/src/view/layout/screenfull/index.vue
@@ -90,7 +90,7 @@ export default {
       screenfull.on('change', this.changeFullShow)
     }
   },
-  destroyed() {
+  unmounted() {
     screenfull.off('change', this.changeFullShow)
   },
   methods: {

--- a/web/src/view/system/state.vue
+++ b/web/src/view/system/state.vue
@@ -159,7 +159,7 @@ export default {
       this.reload()
     }, 1000 * 10)
   },
-  beforeDestroy() {
+  beforeUnmount() {
     clearInterval(this.timer)
     this.timer = null
   },


### PR DESCRIPTION
Vue3中生命周期已不存在`beforeDestroy`钩子，已由`beforeUnmount`代替，参考文档：https://v3.cn.vuejs.org/api/options-lifecycle-hooks.html#beforeunmount

- Vue3文档中改变说明：https://v3.cn.vuejs.org/guide/migration/introduction.html#%E5%85%B6%E4%BB%96%E5%B0%8F%E6%94%B9%E5%8F%98