### PR TITLE
解决echarts和vue存在的冲突问题

### DIFF
--- a/web/src/view/dashboard/dashbordCharts/echartsLine.vue
+++ b/web/src/view/dashboard/dashbordCharts/echartsLine.vue
@@ -11,6 +11,7 @@
 </template>
 <script>
 import echarts from 'echarts'
+import { toRaw } from 'vue'
 import 'echarts/theme/macarons'
 
 var dataAxis = []
@@ -64,7 +65,7 @@ export default {
       this.setOptions()
     },
     setOptions() {
-      this.chart.setOption({
+      toRaw(this.chart).setOption({
         grid: {
           left: '40',
           right: '20',


### PR DESCRIPTION
在vue3中使用echarts存在一个冲突，社区已经有人提及
https://forum.vuejs.org/t/vue3-echarts/105566

核心原因是因为把echarts实例存储在vue实例上，echarts实例被vue3通过proxy转换成响应式对象，最终会导致echarts内部一些组件功能出现异常