### PR TITLE
优化swagger

### DIFF
--- a/server/api/v1/system/sys_captcha.go
+++ b/server/api/v1/system/sys_captcha.go
@@ -15,12 +15,13 @@ var store = base64Captcha.DefaultMemStore
 
 type BaseApi struct{}
 
+// Captcha
 // @Tags Base
 // @Summary 生成验证码
 // @Security ApiKeyAuth
 // @accept application/json
 // @Produce application/json
-// @Success 200 {string} string "{"success":true,"data":{},"msg":"验证码获取成功"}"
+// @Success 200 {object} response.Response{data=systemRes.SysCaptchaResponse} "生成一个随机验证码，返回包括随机生成id，base64 图像字符串，验证码长度"
 // @Router /base/captcha [post]
 func (b *BaseApi) Captcha(c *gin.Context) {
 	// 字符,公式,验证码配置

--- a/server/api/v1/system/sys_captcha.go
+++ b/server/api/v1/system/sys_captcha.go
@@ -18,7 +18,6 @@ type BaseApi struct{}
 // Captcha
 // @Tags Base
 // @Summary 生成验证码
-// @Security ApiKeyAuth
 // @accept application/json
 // @Produce application/json
 // @Success 200 {object} response.Response{data=systemRes.SysCaptchaResponse} "生成一个随机验证码，返回包括随机生成id，base64 图像字符串，验证码长度"

--- a/server/model/system/response/sys_captcha.go
+++ b/server/model/system/response/sys_captcha.go
@@ -1,7 +1,7 @@
 package response
 
 type SysCaptchaResponse struct {
-	CaptchaId     string `json:"captchaId"`
-	PicPath       string `json:"picPath"`
-	CaptchaLength int    `json:"captchaLength""`
+	CaptchaId     string `json:"captchaId" example:"axxbbas"`               // 随机数id
+	PicPath       string `json:"picPath" example:"data:img/png;base64,///"` // base64 图像字符串
+	CaptchaLength int    `json:"captchaLength" example:"6"`                 // 验证码长度
 }


### PR DESCRIPTION
衔接```v2.4.x```优化swagger中，```生成验证码接口```不应该需要鉴权，所以将```@Security```的tag去掉。