### PR TITLE
fix(utils/directory.go): 同名文件存在时正确返回

### DIFF
--- a/server/utils/directory.go
+++ b/server/utils/directory.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"os"
 
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
@@ -14,9 +15,12 @@ import (
 //@return: bool, error
 
 func PathExists(path string) (bool, error) {
-	_, err := os.Stat(path)
+	fi, err := os.Stat(path)
 	if err == nil {
-		return true, nil
+		if fi.IsDir() {
+			return true, nil
+		}
+		return false, errors.New("存在同名文件")
 	}
 	if os.IsNotExist(err) {
 		return false, nil


### PR DESCRIPTION
当存在同名文件时，utils.PathExists()返回false, errors.New("存在同名文件")