### PR TITLE
fix(utils/file_operations.go): 同名目录存在时正确返回

### DIFF
--- a/server/utils/file_operations.go
+++ b/server/utils/file_operations.go
@@ -69,6 +69,9 @@ func TrimSpace(target interface{}) {
 
 // FileExist 判断文件是否存在
 func FileExist(path string) bool {
-	_, err := os.Lstat(path)
+	fi, err := os.Lstat(path)
+	if err == nil {
+		return !fi.IsDir()
+	}
 	return !os.IsNotExist(err)
 }


### PR DESCRIPTION
同名目录存在时，utils.FileExist()返回false