### PR TITLE
这个isSame有问题

### DIFF
--- a/web/src/view/layout/aside/historyComponent/history.vue
+++ b/web/src/view/layout/aside/historyComponent/history.vue
@@ -177,6 +177,9 @@ const isSame = (route1, route2) => {
   if (route1.name !== route2.name) {
     return false
   }
+  if (Object.keys(route1.query).length != Object.keys(route2.query).length || Object.keys(route1.params).length != Object.keys(route2.params).length) {
+    return false
+  }
   for (const key in route1.query) {
     if (route1.query[key] !== route2.query[key]) {
       return false


### PR DESCRIPTION
route1.query={}
route2.query={a:1}
route1的query,params为空时，还是会返回true