### PR TITLE
Fix invalid orderKey

### DIFF
--- a/server/service/system/sys_api.go
+++ b/server/service/system/sys_api.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/common/request"
@@ -89,6 +90,9 @@ func (apiService *ApiService) GetAPIInfoList(api system.SysApi, info request.Pag
 				} else {
 					OrderStr = order
 				}
+			} else { // didn't matched any order key in `orderMap`
+				err = fmt.Errorf("非法的排序字段: %v", order)
+				return err, apiList, total
 			}
 
 			err = db.Order(OrderStr).Find(&apiList).Error

--- a/server/service/system/sys_base_menu.go
+++ b/server/service/system/sys_base_menu.go
@@ -17,7 +17,7 @@ type BaseMenuService struct{}
 //@return: err error
 
 func (baseMenuService *BaseMenuService) DeleteBaseMenu(id int) (err error) {
-	err = global.GVA_DB.Preload("MenuBtn").Preload("Parameters").Where("parent_id = ?", id).First(&system.SysBaseMenu{}).Error
+	err = global.GVA_DB.Preload("Parameters").Where("parent_id = ?", id).First(&system.SysBaseMenu{}).Error
 	if err != nil {
 		var menu system.SysBaseMenu
 		db := global.GVA_DB.Preload("SysAuthoritys").Where("id = ?", id).First(&menu).Delete(&menu)
@@ -119,6 +119,6 @@ func (baseMenuService *BaseMenuService) UpdateBaseMenu(menu system.SysBaseMenu) 
 //@return: err error, menu model.SysBaseMenu
 
 func (baseMenuService *BaseMenuService) GetBaseMenuById(id int) (err error, menu system.SysBaseMenu) {
-	err = global.GVA_DB.Preload("MenuBtn").Preload("Parameters").Where("id = ?", id).First(&menu).Error
+	err = global.GVA_DB.Preload("Parameters").Where("id = ?", id).First(&menu).Error
 	return
 }

--- a/server/service/system/sys_base_menu.go
+++ b/server/service/system/sys_base_menu.go
@@ -17,7 +17,7 @@ type BaseMenuService struct{}
 //@return: err error
 
 func (baseMenuService *BaseMenuService) DeleteBaseMenu(id int) (err error) {
-	err = global.GVA_DB.Preload("Parameters").Where("parent_id = ?", id).First(&system.SysBaseMenu{}).Error
+	err = global.GVA_DB.Preload("MenuBtn").Preload("Parameters").Where("parent_id = ?", id).First(&system.SysBaseMenu{}).Error
 	if err != nil {
 		var menu system.SysBaseMenu
 		db := global.GVA_DB.Preload("SysAuthoritys").Where("id = ?", id).First(&menu).Delete(&menu)
@@ -119,6 +119,6 @@ func (baseMenuService *BaseMenuService) UpdateBaseMenu(menu system.SysBaseMenu) 
 //@return: err error, menu model.SysBaseMenu
 
 func (baseMenuService *BaseMenuService) GetBaseMenuById(id int) (err error, menu system.SysBaseMenu) {
-	err = global.GVA_DB.Preload("Parameters").Where("id = ?", id).First(&menu).Error
+	err = global.GVA_DB.Preload("MenuBtn").Preload("Parameters").Where("id = ?", id).First(&menu).Error
 	return
 }


### PR DESCRIPTION
related issue: #936 
## Description
### How to reproduce
当此接口`/api/getApiList`入参`orderKey`不为以下["id","path","api_group","description","method"]之一时 ,即可复现。
### How it works
当接口入参`orderKey`非法时，如“ID”,执行到下游函数`func (apiService *ApiService) GetAPIInfoList`中时会导致:`OrderStr==""`，从而此处`err = db.Order(OrderStr).Find(&apiList).Error`构造出#936 所描述异常SQL语句。
加入else分支捕捉`apiService.GetAPIInfoList`函数入参order不为空但非法的情况。如非法的order值即报错返回。