### PR TITLE
修改了Ram拼写错误

### DIFF
--- a/server/service/system/sys_system.go
+++ b/server/service/system/sys_system.go
@@ -47,7 +47,7 @@ func (systemConfigService *SystemConfigService) GetServerInfo() (server *utils.S
 		global.GVA_LOG.Error("func utils.InitCPU() Failed", zap.String("err", err.Error()))
 		return &s, err
 	}
-	if s.Rrm, err = utils.InitRAM(); err != nil {
+	if s.Ram, err = utils.InitRAM(); err != nil {
 		global.GVA_LOG.Error("func utils.InitRAM() Failed", zap.String("err", err.Error()))
 		return &s, err
 	}

--- a/server/utils/server.go
+++ b/server/utils/server.go
@@ -19,7 +19,7 @@ const (
 type Server struct {
 	Os   Os   `json:"os"`
 	Cpu  Cpu  `json:"cpu"`
-	Rrm  Rrm  `json:"ram"`
+	Ram  Ram  `json:"ram"`
 	Disk Disk `json:"disk"`
 }
 
@@ -36,7 +36,7 @@ type Cpu struct {
 	Cores int       `json:"cores"`
 }
 
-type Rrm struct {
+type Ram struct {
 	UsedMB      int `json:"usedMb"`
 	TotalMB     int `json:"totalMb"`
 	UsedPercent int `json:"usedPercent"`
@@ -85,10 +85,10 @@ func InitCPU() (c Cpu, err error) {
 
 //@author: [SliverHorn](https://github.com/SliverHorn)
 //@function: InitRAM
-//@description: ARM信息
-//@return: r Rrm, err error
+//@description: RAM信息
+//@return: r Ram, err error
 
-func InitRAM() (r Rrm, err error) {
+func InitRAM() (r Ram, err error) {
 	if u, err := mem.VirtualMemory(); err != nil {
 		return r, err
 	} else {


### PR DESCRIPTION
service/system/sys_system.go:43 查看服务器信息的函数返回结构体里的错别字，对逻辑无影响
utils/server.go:22 Rrm改为Ram
