### PR TITLE
修复 Token 失效后导致的白屏问题

### DIFF
--- a/web/src/permission.js
+++ b/web/src/permission.js
@@ -58,7 +58,14 @@ router.beforeEach(async(to, from, next) => {
       if (!asyncRouterFlag && whiteList.indexOf(from.name) < 0) {
         asyncRouterFlag++
         await getRouter(userStore)
-        next({ ...to, replace: true })
+        if (userStore.token) {
+          next({ ...to, replace: true })
+        } else {
+          next({
+            name: 'Login',
+            query: { redirect: to.href }
+          })
+        }
       } else {
         if (to.matched.length) {
           next()


### PR DESCRIPTION
复现步骤:
1. 登录后拉黑 Token 或将 localStorage 里的 Token改为任意值
2. F5 刷新页面
3. 页面提示 "That's not even a token"  "未登录或非法访问", 并导致了白屏无响应

控制台报错:
`
[Vue Router warn]: Unexpected error when starting the router: RangeError: Maximum call stack size exceeded
    at Object.resolve (vue-router.esm-bundler.js:1406:5)
    at resolve (vue-router.esm-bundler.js:2912:38)
    at pushWithRedirect (vue-router.esm-bundler.js:3000:51)
    at pushWithRedirect (vue-router.esm-bundler.js:3008:20)
    at pushWithRedirect (vue-router.esm-bundler.js:3008:20)
    at pushWithRedirect (vue-router.esm-bundler.js:3008:20)
    at pushWithRedirect (vue-router.esm-bundler.js:3008:20)
    at pushWithRedirect (vue-router.esm-bundler.js:3008:20)
    at pushWithRedirect (vue-router.esm-bundler.js:3008:20)
    at pushWithRedirect (vue-router.esm-bundler.js:3008:20)
`

原因: 
执行 `permission.js` 路由守卫时, 带有已失效的Token并执行 `await getRouter(userStore)`. 该接口会报错"token无效", 导致无法获取到路由列表, 继续进入页面时会触发`/:catchAll(.*)`重定向至`/layout/404`. 但`/layout/404`路由只会在加载路由成功时插入路由, 导致再次重定向至`/:catchAll(.*)`,  发生循环调用.

解决方案:
在加载路由后, 重新判断 Token 是否还有效. 


