### PR TITLE
增加make命令操作，以及自动化流程

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM centos:7
+WORKDIR /opt
+ENV LANG=en_US.utf8
+COPY entrypoint.sh .
+COPY build/ /usr/share/nginx/html/
+COPY server/config.yaml /usr/share/nginx/html/config.yaml
+COPY web/.docker-compose/nginx/conf.d/nginx.conf /etc/nginx/conf.d/nginx.conf
+RUN set -ex \
+    && echo "LANG=en_US.utf8" > /etc/locale.conf \
+    && echo "net.core.somaxconn = 1024" >> /etc/sysctl.conf \
+    && echo "vm.overcommit_memory = 1" >> /etc/sysctl.conf \
+    && yum -y install yum -y install *epel* \
+    && yum -y localinstall http://mirrors.ustc.edu.cn/mysql-repo/mysql57-community-release-el7.rpm \
+    && yum -y install mysql-community-server git redis nginx go npm --nogpgcheck && chmod +x ./entrypoint.sh \
+    && npm install -g yarn && go env -w GO111MODULE=on && go env -w GOPROXY=https://goproxy.cn,direct \
+    && echo "start" > /dev/null
+EXPOSE 80
+ENTRYPOINT ["./entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+SHELL = /bin/bash
+
+CONFIG_FILE         = config.yaml
+PROJECT_NAME        = github.com/flipped-aurora/gin-vue-admin/server
+#SCRIPT_DIR         = $(shell pwd)/etc/script
+BUILD_IMAGE_SERVER  = golang:1.16
+BUILD_IMAGE_WEB     = node:16
+IMAGE_NAME          = gva
+REPOSITORY          = registry.cn-hangzhou.aliyuncs.com/${IMAGE_NAME}
+
+ifeq ($(TAGS_OPT),)
+TAGS_OPT            = 2.5.0b
+else
+endif
+
+#前后端共同打包
+build: build-web build-server
+	docker run --name build-local --rm -v $(shell pwd):/go/src/${PROJECT_NAME} -w /go/src/${PROJECT_NAME} ${BUILD_IMAGE_SERVER} make build-local
+
+#容器打包前端
+build-web:
+	docker run --name build-web-local --rm -v $(shell pwd):/go/src/${PROJECT_NAME} -w /go/src/${PROJECT_NAME} ${BUILD_IMAGE_WEB} make build-web-local
+
+#容器打包后端
+build-server:
+	docker run --name build-server-local --rm -v $(shell pwd):/go/src/${PROJECT_NAME} -w /go/src/${PROJECT_NAME} ${BUILD_IMAGE_SERVER} make build-server-local
+
+#构建web镜像
+build-image-web:
+	@cd web/ && docker build -t ${REPOSITORY}/web:${TAGS_OPT} .
+
+#构建server镜像
+build-image-server:
+	@cd server/ && docker build -t ${REPOSITORY}/server:${TAGS_OPT} .
+
+#本地环境打包前后端
+build-local:
+	if [ -d "build" ];then rm -rf build; else echo "OK!"; fi \
+	&& if [ -f "/.dockerenv" ];then echo "OK!"; else  make build-web-local && make build-server-local; fi \
+	&& mkdir build && cp -r web/dist build/ && cp server/server build/ && cp -r server/resource build/resource 
+
+#本地环境打包前端
+build-web-local:
+	@cd web/ && if [ -d "dist" ];then rm -rf dist; else echo "OK!"; fi \
+	&& yarn config set registry http://mirrors.cloud.tencent.com/npm/ \
+	&& yarn install && yarn build
+
+#本地环境打包后端
+build-server-local:
+	@cd server/ && if [ -f "server" ];then rm -rf server; else echo "OK!"; fi \
+	&& go env -w GO111MODULE=on && go env -w GOPROXY=https://goproxy.cn,direct \
+	&& go env -w CGO_ENABLED=0 && go env  && go mod tidy \
+	&& go build -ldflags "-B 0x$(shell head -c20 /dev/urandom|od -An -tx1|tr -d ' \n') -X main.Version=${TAGS_OPT}" -v
+
+#镜像待优化自动化版本
+images: build build-image-web build-image-server
+	docker build -t ${REPOSITORY}/all:${TAGS_OPT} .

--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,15 @@ TAGS_OPT            = 2.5.0b
 else
 endif
 
-#前后端共同打包
+#容器环境前后端共同打包
 build: build-web build-server
 	docker run --name build-local --rm -v $(shell pwd):/go/src/${PROJECT_NAME} -w /go/src/${PROJECT_NAME} ${BUILD_IMAGE_SERVER} make build-local
 
-#容器打包前端
+#容器环境打包前端
 build-web:
 	docker run --name build-web-local --rm -v $(shell pwd):/go/src/${PROJECT_NAME} -w /go/src/${PROJECT_NAME} ${BUILD_IMAGE_WEB} make build-web-local
 
-#容器打包后端
+#容器环境打包后端
 build-server:
 	docker run --name build-server-local --rm -v $(shell pwd):/go/src/${PROJECT_NAME} -w /go/src/${PROJECT_NAME} ${BUILD_IMAGE_SERVER} make build-server-local
 
@@ -52,6 +52,10 @@ build-server-local:
 	&& go env -w CGO_ENABLED=0 && go env  && go mod tidy \
 	&& go build -ldflags "-B 0x$(shell head -c20 /dev/urandom|od -An -tx1|tr -d ' \n') -X main.Version=${TAGS_OPT}" -v
 
-#镜像待优化自动化版本
+#打包前后端二合一镜像
+image: build 
+	docker build -t ${REPOSITORY}/all-one:${TAGS_OPT} .
+
+#尝鲜版
 images: build build-image-web build-image-server
 	docker build -t ${REPOSITORY}/all:${TAGS_OPT} .

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+if [ ! -d "/var/lib/mysql/gva" ]; then
+    mysqld --initialize-insecure --user=mysql --datadir=/var/lib/mysql
+    mysqld --daemonize --user=mysql
+    sleep 5s
+    mysql -uroot -e "create database gva default charset 'utf8' collate 'utf8_bin'; grant all on gva.* to 'root'@'127.0.0.1' identified by '123456'; flush privileges;"
+else
+    mysqld --daemonize --user=mysql
+fi
+redis-server &
+if [ "$1" = "actions" ]; then
+    cd /opt/gva/server && go run main.go &
+    cd /opt/gva/web/ && yarn serve &
+else 
+    /usr/sbin/nginx &
+    cd /usr/share/nginx/html/ && ./server &
+fi
+echo "gva ALL start!!!"
+tail -f /dev/null

--- a/server/api/v1/system/sys_user.go
+++ b/server/api/v1/system/sys_user.go
@@ -295,6 +295,7 @@ func (b *BaseApi) SetUserInfo(c *gin.Context) {
 		HeaderImg: user.HeaderImg,
 		Phone:     user.Phone,
 		Email:     user.Email,
+		SideMode:  user.SideMode,
 	}); err != nil {
 		global.GVA_LOG.Error("设置失败!", zap.Error(err))
 		response.FailWithMessage("设置失败", c)
@@ -323,6 +324,7 @@ func (b *BaseApi) SetSelfInfo(c *gin.Context) {
 		HeaderImg: user.HeaderImg,
 		Phone:     user.Phone,
 		Email:     user.Email,
+		SideMode:  user.SideMode,
 	}); err != nil {
 		global.GVA_LOG.Error("设置失败!", zap.Error(err))
 		response.FailWithMessage("设置失败", c)

--- a/server/model/system/request/sys_user.go
+++ b/server/model/system/request/sys_user.go
@@ -45,5 +45,6 @@ type ChangeUserInfo struct {
 	AuthorityIds []string             `json:"authorityIds" gorm:"-"`                                                                // 角色ID
 	Email        string               `json:"email"  gorm:"comment:用户邮箱"`                                                           // 用户邮箱
 	HeaderImg    string               `json:"headerImg" gorm:"default:https://qmplusimg.henrongyi.top/gva_header.jpg;comment:用户头像"` // 用户头像
+	SideMode     string               `json:"sideMode"  gorm:"comment:用户侧边主题"`                                                      // 用户侧边主题
 	Authorities  []model.SysAuthority `json:"-" gorm:"many2many:sys_user_authority;"`
 }

--- a/web/.docker-compose/nginx/conf.d/nginx.conf
+++ b/web/.docker-compose/nginx/conf.d/nginx.conf
@@ -1,0 +1,32 @@
+server {
+    listen  80;
+    server_name localhost;
+
+    #charset koi8-r;
+    #access_log  logs/host.access.log  main;
+
+    location / {
+        root /usr/share/nginx/html/dist;
+        add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api {
+        proxy_set_header Host $http_host;
+        proxy_set_header  X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        rewrite ^/api/(.*)$ /$1 break;  #重写
+        proxy_pass http://127.0.0.1:8888; # 设置代理服务器的协议和地址
+     }
+    location  /form-generator {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://127.0.0.1:8888;
+    }
+    location /api/swagger/index.html {
+        proxy_pass http://127.0.0.1:8888/swagger/index.html;
+     }
+ }


### PR DESCRIPTION
功能一：提交main分支代码，会自动更新镜像
    registry.cn-hangzhou.aliyuncs.com/gva/web:latest
    registry.cn-hangzhou.aliyuncs.com/gva/server:latest
    registry.cn-hangzhou.aliyuncs.com/gva/all:latest

功能二：增加尝鲜版镜像，不适合应用于生产，只用于体验功能
    docker run -d -p 8080:8080 -p 8888:8888 registry.cn-hangzhou.aliyuncs.com/gva/all
    启动后需要等待2分钟，初始化不需要更改任何数据，直接点击确认即可

   附：前后端数据库三合一镜像demo，可使用make image创建
          docker run -d -p 80:80 registry.cn-hangzhou.aliyuncs.com/gva/all-one
          由于是打过包的，没有自动化创建代码功能。

功能三：增加make命令，其中go后端使用-ldflags镶入版本号

    #前后端共同容器内打包
    make build

    #本地环境打包前后端
    make build-local

    #容器内打包前端
    make build-web

    #本地环境打包前端
    make build-web-local

    #容器打包后端
    make build-server

    #本地环境打包后端
    make build-server-local

    #构建本地web镜像
    make build-image-web

    #构建本地server镜像
    make build-image-server

    #制作前后端打包版二合一镜像
    make image

