### PR TITLE
修复分片上传-寻找目标文件（秒传）的请求方式有误

### DIFF
--- a/server/source/system/api.go
+++ b/server/source/system/api.go
@@ -86,7 +86,7 @@ func (i *initApi) InitializeData(ctx context.Context) (context.Context, error) {
 		{ApiGroup: "菜单", Method: "POST", Path: "/menu/getMenuAuthority", Description: "获取指定角色menu"},
 		{ApiGroup: "菜单", Method: "POST", Path: "/menu/addMenuAuthority", Description: "增加menu和角色关联关系"},
 
-		{ApiGroup: "分片上传", Method: "POST", Path: "/fileUploadAndDownload/findFile", Description: "寻找目标文件（秒传）"},
+		{ApiGroup: "分片上传", Method: "GET", Path: "/fileUploadAndDownload/findFile", Description: "寻找目标文件（秒传）"},
 		{ApiGroup: "分片上传", Method: "POST", Path: "/fileUploadAndDownload/breakpointContinue", Description: "断点续传"},
 		{ApiGroup: "分片上传", Method: "POST", Path: "/fileUploadAndDownload/breakpointContinueFinish", Description: "断点续传完成"},
 		{ApiGroup: "分片上传", Method: "POST", Path: "/fileUploadAndDownload/removeChunk", Description: "上传完成移除文件"},


### PR DESCRIPTION
会造成的问题是：项目初始化后，在菜单管理页面可以看到这个api的方式是post，然后再角色管理里面，普通用户的角色api的分片上传组-寻找目标文件（秒传）是没有选中的，如果勾选上点击确定提交，会造成断点续传功能无法上传文件，casbin校验不通过，因为数据被修改了。
如果对角色api这个复选框没有选中的情况不进行操作的话，不影响断点续传功能使用。