### PR TITLE
fix: 修复初始化PostgreSQL时尝试数据库连接验证时用户名同名数据库不存在导致的初始化失败问题

### DIFF
--- a/server/model/system/request/sys_init.go
+++ b/server/model/system/request/sys_init.go
@@ -34,9 +34,9 @@ func (i *InitDB) PgsqlEmptyDsn() string {
 		i.Host = "127.0.0.1"
 	}
 	if i.Port == "" {
-		i.Port = "3306"
+		i.Port = "5432"
 	}
-	return "host=" + i.Host + " user=" + i.UserName + " password=" + i.Password + " port=" + i.Port + " " + "sslmode=disable TimeZone=Asia/Shanghai"
+	return "host=" + i.Host + " user=" + i.UserName + " password=" + i.Password + " port=" + i.Port + " dbname=" + "postgres" + " " + "sslmode=disable TimeZone=Asia/Shanghai"
 }
 
 // ToMysqlConfig 转换 config.Mysql


### PR DESCRIPTION
https://www.postgresql.org/docs/current/app-initdb.html

The postgres database is a default database meant for use by users, utilities and third party applications.

默认数据库postgres一般存在,但用户名同名数据库不一定存在