### PR TITLE
feature: viper 读取gin自带的环境变量GIN_MODE,用于区分开发,测试,生产三个环境 #1098

### DIFF
--- a/server/core/internal/constant.go
+++ b/server/core/internal/constant.go
@@ -1,0 +1,9 @@
+package internal
+
+const (
+	ConfigEnv         = "GVA_CONFIG"
+	ConfigDefaultFile = "config.yaml"
+	ConfigTestFile    = "config.test.yaml"
+	ConfigDebugFile   = "config.debug.yaml"
+	ConfigReleaseFile = "config.release.yaml"
+)

--- a/server/core/viper.go
+++ b/server/core/viper.go
@@ -3,6 +3,8 @@ package core
 import (
 	"flag"
 	"fmt"
+	"github.com/flipped-aurora/gin-vue-admin/server/core/internal"
+	"github.com/gin-gonic/gin"
 	"os"
 	"path/filepath"
 	"time"
@@ -11,31 +13,42 @@ import (
 
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	_ "github.com/flipped-aurora/gin-vue-admin/server/packfile"
-	"github.com/flipped-aurora/gin-vue-admin/server/utils"
-
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/viper"
 )
 
+// Viper //
+// 优先级: 命令行 > 环境变量 > 默认值
+// Author [SliverHorn](https://github.com/SliverHorn)
 func Viper(path ...string) *viper.Viper {
 	var config string
+
 	if len(path) == 0 {
 		flag.StringVar(&config, "c", "", "choose config file.")
 		flag.Parse()
-		if config == "" { // 优先级: 命令行 > 环境变量 > 默认值
-			if configEnv := os.Getenv(utils.ConfigEnv); configEnv == "" {
-				config = utils.ConfigFile
-				fmt.Printf("您正在使用config的默认值,config的路径为%v\n", utils.ConfigFile)
-			} else {
+		if config == "" { // 判断命令行参数是否为空
+			if configEnv := os.Getenv(internal.ConfigEnv); configEnv == "" { // 判断 internal.ConfigEnv 常量存储的环境变量是否为空
+				switch gin.Mode() {
+				case gin.DebugMode:
+					config = internal.ConfigDefaultFile
+					fmt.Printf("您正在使用gin模式的%s环境名称,config的路径为%s\n", gin.EnvGinMode, internal.ConfigDefaultFile)
+				case gin.ReleaseMode:
+					config = internal.ConfigReleaseFile
+					fmt.Printf("您正在使用gin模式的%s环境名称,config的路径为%s\n", gin.EnvGinMode, internal.ConfigReleaseFile)
+				case gin.TestMode:
+					config = internal.ConfigTestFile
+					fmt.Printf("您正在使用gin模式的%s环境名称,config的路径为%s\n", gin.EnvGinMode, internal.ConfigTestFile)
+				}
+			} else { // internal.ConfigEnv 常量存储的环境变量不为空 将值赋值于config
 				config = configEnv
-				fmt.Printf("您正在使用GVA_CONFIG环境变量,config的路径为%v\n", config)
+				fmt.Printf("您正在使用%s环境变量,config的路径为%s\n", internal.ConfigEnv, config)
 			}
-		} else {
-			fmt.Printf("您正在使用命令行的-c参数传递的值,config的路径为%v\n", config)
+		} else { // 命令行参数不为空 将值赋值于config
+			fmt.Printf("您正在使用命令行的-c参数传递的值,config的路径为%s\n", config)
 		}
-	} else {
+	} else { // 函数传递的可变参数的第一个值赋值于config
 		config = path[0]
-		fmt.Printf("您正在使用func Viper()传递的值,config的路径为%v\n", config)
+		fmt.Printf("您正在使用func Viper()传递的值,config的路径为%s\n", config)
 	}
 
 	v := viper.New()
@@ -49,15 +62,15 @@ func Viper(path ...string) *viper.Viper {
 
 	v.OnConfigChange(func(e fsnotify.Event) {
 		fmt.Println("config file changed:", e.Name)
-		if err := v.Unmarshal(&global.GVA_CONFIG); err != nil {
+		if err = v.Unmarshal(&global.GVA_CONFIG); err != nil {
 			fmt.Println(err)
 		}
 	})
-	if err := v.Unmarshal(&global.GVA_CONFIG); err != nil {
+	if err = v.Unmarshal(&global.GVA_CONFIG); err != nil {
 		fmt.Println(err)
 	}
-	// root 适配性
-	// 根据root位置去找到对应迁移位置,保证root路径有效
+
+	// root 适配性 根据root位置去找到对应迁移位置,保证root路径有效
 	global.GVA_CONFIG.AutoCode.Root, _ = filepath.Abs("..")
 	global.BlackCache = local_cache.NewCache(
 		local_cache.SetDefaultExpire(time.Second * time.Duration(global.GVA_CONFIG.JWT.ExpiresTime)),

--- a/server/utils/constant.go
+++ b/server/utils/constant.go
@@ -1,6 +1,0 @@
-package utils
-
-const (
-	ConfigEnv  = "GVA_CONFIG"
-	ConfigFile = "config.yaml"
-)


### PR DESCRIPTION
## 注意
- 为了对原系统破坏性最低，server/core/viper.go 的 33,34行 定义为config.yaml
   如果想要标准化 开发,测试,生产 三个环境的config不一样, 可用以下代码代替 server/core/viper.go的33,34行
   ```go
   config = internal.ConfigDebugFile
   fmt.Printf("您正在使用gin模式的%s环境名称,config的路径为%s\n", gin.EnvGinMode, internal.ConfigDebugFile)
   ```
- 注意设置gin的环境变量 GIN_MODE 时，GIN_MODE 只能有三个值，debug、release、test， 其他值会panic的