### PR TITLE
修复issues #1118

### DIFF
--- a/server/config/zap.go
+++ b/server/config/zap.go
@@ -1,6 +1,9 @@
 package config
 
-import "go.uber.org/zap/zapcore"
+import (
+	"go.uber.org/zap/zapcore"
+	"strings"
+)
 
 type Zap struct {
 	Level         string `mapstructure:"level" json:"level" yaml:"level"`                            // 级别
@@ -29,5 +32,29 @@ func (z *Zap) ZapEncodeLevel() zapcore.LevelEncoder {
 		return zapcore.CapitalColorLevelEncoder
 	default:
 		return zapcore.LowercaseLevelEncoder
+	}
+}
+
+// TransportLevel 根据字符串转化为 zapcore.Level
+// Author [SliverHorn](https://github.com/SliverHorn)
+func (z *Zap) TransportLevel() zapcore.Level {
+	z.Level = strings.ToLower(z.Level)
+	switch z.Level {
+	case "debug":
+		return zapcore.DebugLevel
+	case "info":
+		return zapcore.InfoLevel
+	case "warn":
+		return zapcore.WarnLevel
+	case "error":
+		return zapcore.WarnLevel
+	case "dpanic":
+		return zapcore.DPanicLevel
+	case "panic":
+		return zapcore.PanicLevel
+	case "fatal":
+		return zapcore.FatalLevel
+	default:
+		return zapcore.DebugLevel
 	}
 }

--- a/server/config/zap.go
+++ b/server/config/zap.go
@@ -1,5 +1,7 @@
 package config
 
+import "go.uber.org/zap/zapcore"
+
 type Zap struct {
 	Level         string `mapstructure:"level" json:"level" yaml:"level"`                            // 级别
 	Prefix        string `mapstructure:"prefix" json:"prefix" yaml:"prefix"`                         // 日志前缀
@@ -11,4 +13,21 @@ type Zap struct {
 	MaxAge       int  `mapstructure:"mintage" json:"max-age" yaml:"max-age"`                      // 日志留存时间
 	ShowLine     bool `mapstructure:"show-line" json:"show-line" yaml:"show-line"`                // 显示行
 	LogInConsole bool `mapstructure:"log-in-console" json:"log-in-console" yaml:"log-in-console"` // 输出控制台
+}
+
+// ZapEncodeLevel 根据 EncodeLevel 返回 zapcore.LevelEncoder
+// Author [SliverHorn](https://github.com/SliverHorn)
+func (z *Zap) ZapEncodeLevel() zapcore.LevelEncoder {
+	switch {
+	case z.EncodeLevel == "LowercaseLevelEncoder": // 小写编码器(默认)
+		return zapcore.LowercaseLevelEncoder
+	case z.EncodeLevel == "LowercaseColorLevelEncoder": // 小写编码器带颜色
+		return zapcore.LowercaseColorLevelEncoder
+	case z.EncodeLevel == "CapitalLevelEncoder": // 大写编码器
+		return zapcore.CapitalLevelEncoder
+	case z.EncodeLevel == "CapitalColorLevelEncoder": // 大写编码器带颜色
+		return zapcore.CapitalColorLevelEncoder
+	default:
+		return zapcore.LowercaseLevelEncoder
+	}
 }

--- a/server/core/internal/file_rotatelogs.go
+++ b/server/core/internal/file_rotatelogs.go
@@ -18,7 +18,6 @@ type fileRotatelogs struct{}
 func (r *fileRotatelogs) GetWriteSyncer(level string) (zapcore.WriteSyncer, error) {
 	fileWriter, err := rotatelogs.New(
 		path.Join(global.GVA_CONFIG.Zap.Director, "%Y-%m-%d", level+".log"),
-		rotatelogs.ForceNewFile(),
 		rotatelogs.WithClock(rotatelogs.Local),
 		rotatelogs.WithMaxAge(time.Duration(global.GVA_CONFIG.Zap.MaxAge)*24*time.Hour), // 日志留存时间
 		rotatelogs.WithRotationTime(time.Hour*24),

--- a/server/core/internal/zap.go
+++ b/server/core/internal/zap.go
@@ -61,30 +61,8 @@ func (z *_zap) CustomTimeEncoder(t time.Time, encoder zapcore.PrimitiveArrayEnco
 // Author [SliverHorn](https://github.com/SliverHorn)
 func (z *_zap) GetZapCores() []zapcore.Core {
 	cores := make([]zapcore.Core, 0, 7)
-	debugCore := z.GetEncoderCore(zap.DebugLevel, z.GetLevelPriority(zap.DebugLevel))
-	infoCore := z.GetEncoderCore(zap.InfoLevel, z.GetLevelPriority(zap.InfoLevel))
-	warnCore := z.GetEncoderCore(zap.WarnLevel, z.GetLevelPriority(zap.WarnLevel))
-	errorCore := z.GetEncoderCore(zap.ErrorLevel, z.GetLevelPriority(zap.ErrorLevel))
-	dPanicCore := z.GetEncoderCore(zap.DPanicLevel, z.GetLevelPriority(zap.DPanicLevel))
-	panicCore := z.GetEncoderCore(zap.PanicLevel, z.GetLevelPriority(zap.PanicLevel))
-	fatalCore := z.GetEncoderCore(zap.FatalLevel, z.GetLevelPriority(zap.FatalLevel))
-	switch global.GVA_CONFIG.Zap.Level {
-	case "debug", "DEBUG":
-		cores = append(cores, debugCore, infoCore, warnCore, errorCore, dPanicCore, panicCore, fatalCore)
-	case "info", "INFO":
-		cores = append(cores, infoCore, warnCore, errorCore, dPanicCore, panicCore, fatalCore)
-	case "warn", "WARN":
-		cores = append(cores, warnCore, errorCore, dPanicCore, panicCore, fatalCore)
-	case "error", "ERROR":
-		cores = append(cores, errorCore, dPanicCore, panicCore, fatalCore)
-	case "dpanic", "DPANIC":
-		cores = append(cores, dPanicCore, panicCore, fatalCore)
-	case "panic", "PANIC":
-		cores = append(cores, panicCore, fatalCore)
-	case "fatal", "FATAL":
-		cores = append(cores, fatalCore)
-	default:
-		cores = append(cores, debugCore, infoCore, warnCore, errorCore, dPanicCore, panicCore, fatalCore)
+	for level := global.GVA_CONFIG.Zap.TransportLevel(); level <= zapcore.FatalLevel; level++ {
+		cores = append(cores, z.GetEncoderCore(level, z.GetLevelPriority(level)))
 	}
 	return cores
 }

--- a/server/core/internal/zap.go
+++ b/server/core/internal/zap.go
@@ -1,0 +1,129 @@
+package internal
+
+import (
+	"fmt"
+	"github.com/flipped-aurora/gin-vue-admin/server/global"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"time"
+)
+
+var Zap = new(_zap)
+
+type _zap struct{}
+
+// GetEncoder 获取 zapcore.Encoder
+// Author [SliverHorn](https://github.com/SliverHorn)
+func (z *_zap) GetEncoder() zapcore.Encoder {
+	if global.GVA_CONFIG.Zap.Format == "json" {
+		return zapcore.NewJSONEncoder(z.GetEncoderConfig())
+	}
+	return zapcore.NewConsoleEncoder(z.GetEncoderConfig())
+}
+
+// GetEncoderConfig 获取zapcore.EncoderConfig
+// Author [SliverHorn](https://github.com/SliverHorn)
+func (z *_zap) GetEncoderConfig() zapcore.EncoderConfig {
+	return zapcore.EncoderConfig{
+		MessageKey:     "message",
+		LevelKey:       "level",
+		TimeKey:        "time",
+		NameKey:        "logger",
+		CallerKey:      "caller",
+		StacktraceKey:  global.GVA_CONFIG.Zap.StacktraceKey,
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeLevel:    global.GVA_CONFIG.Zap.ZapEncodeLevel(),
+		EncodeTime:     z.CustomTimeEncoder,
+		EncodeDuration: zapcore.SecondsDurationEncoder,
+		EncodeCaller:   zapcore.FullCallerEncoder,
+	}
+}
+
+// GetEncoderCore 获取Encoder的 zapcore.Core
+// Author [SliverHorn](https://github.com/SliverHorn)
+func (z *_zap) GetEncoderCore(l zapcore.Level, level zap.LevelEnablerFunc) zapcore.Core {
+	writer, err := FileRotatelogs.GetWriteSyncer(l.String()) // 使用file-rotatelogs进行日志分割
+	if err != nil {
+		fmt.Printf("Get Write Syncer Failed err:%v", err.Error())
+		return nil
+	}
+
+	return zapcore.NewCore(z.GetEncoder(), writer, level)
+}
+
+// CustomTimeEncoder 自定义日志输出时间格式
+// Author [SliverHorn](https://github.com/SliverHorn)
+func (z *_zap) CustomTimeEncoder(t time.Time, encoder zapcore.PrimitiveArrayEncoder) {
+	encoder.AppendString(t.Format(global.GVA_CONFIG.Zap.Prefix + "2006/01/02 - 15:04:05.000"))
+}
+
+// GetZapCores 根据配置文件的Level获取 []zapcore.Core
+// Author [SliverHorn](https://github.com/SliverHorn)
+func (z *_zap) GetZapCores() []zapcore.Core {
+	cores := make([]zapcore.Core, 0, 7)
+	debugCore := z.GetEncoderCore(zap.DebugLevel, z.GetLevelPriority(zap.DebugLevel))
+	infoCore := z.GetEncoderCore(zap.InfoLevel, z.GetLevelPriority(zap.InfoLevel))
+	warnCore := z.GetEncoderCore(zap.WarnLevel, z.GetLevelPriority(zap.WarnLevel))
+	errorCore := z.GetEncoderCore(zap.ErrorLevel, z.GetLevelPriority(zap.ErrorLevel))
+	dPanicCore := z.GetEncoderCore(zap.DPanicLevel, z.GetLevelPriority(zap.DPanicLevel))
+	panicCore := z.GetEncoderCore(zap.PanicLevel, z.GetLevelPriority(zap.PanicLevel))
+	fatalCore := z.GetEncoderCore(zap.FatalLevel, z.GetLevelPriority(zap.FatalLevel))
+	switch global.GVA_CONFIG.Zap.Level {
+	case "debug", "DEBUG":
+		cores = append(cores, debugCore, infoCore, warnCore, errorCore, dPanicCore, panicCore, fatalCore)
+	case "info", "INFO":
+		cores = append(cores, infoCore, warnCore, errorCore, dPanicCore, panicCore, fatalCore)
+	case "warn", "WARN":
+		cores = append(cores, warnCore, errorCore, dPanicCore, panicCore, fatalCore)
+	case "error", "ERROR":
+		cores = append(cores, errorCore, dPanicCore, panicCore, fatalCore)
+	case "dpanic", "DPANIC":
+		cores = append(cores, dPanicCore, panicCore, fatalCore)
+	case "panic", "PANIC":
+		cores = append(cores, panicCore, fatalCore)
+	case "fatal", "FATAL":
+		cores = append(cores, fatalCore)
+	default:
+		cores = append(cores, debugCore, infoCore, warnCore, errorCore, dPanicCore, panicCore, fatalCore)
+	}
+	return cores
+}
+
+// GetLevelPriority 根据 zapcore.Level 获取 zap.LevelEnablerFunc
+// Author [SliverHorn](https://github.com/SliverHorn)
+func (z *_zap) GetLevelPriority(level zapcore.Level) zap.LevelEnablerFunc {
+	switch level {
+	case zapcore.DebugLevel:
+		return func(level zapcore.Level) bool { // 调试级别
+			return level == zap.DebugLevel
+		}
+	case zapcore.InfoLevel:
+		return func(level zapcore.Level) bool { // 日志级别
+			return level == zap.InfoLevel
+		}
+	case zapcore.WarnLevel:
+		return func(level zapcore.Level) bool { // 警告级别
+			return level == zap.WarnLevel
+		}
+	case zapcore.ErrorLevel:
+		return func(level zapcore.Level) bool { // 错误级别
+			return level == zap.ErrorLevel
+		}
+	case zapcore.DPanicLevel:
+		return func(level zapcore.Level) bool { // dpanic级别
+			return level == zap.DPanicLevel
+		}
+	case zapcore.PanicLevel:
+		return func(level zapcore.Level) bool { // panic级别
+			return level == zap.PanicLevel
+		}
+	case zapcore.FatalLevel:
+		return func(level zapcore.Level) bool { // 终止级别
+			return level == zap.FatalLevel
+		}
+	default:
+		return func(level zapcore.Level) bool { // 调试级别
+			return level == zap.DebugLevel
+		}
+	}
+}

--- a/server/core/zap.go
+++ b/server/core/zap.go
@@ -3,13 +3,11 @@ package core
 import (
 	"fmt"
 	"github.com/flipped-aurora/gin-vue-admin/server/core/internal"
-	"os"
-	"time"
-
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/utils"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"os"
 )
 
 // Zap 获取 zap.Logger
@@ -20,93 +18,11 @@ func Zap() (logger *zap.Logger) {
 		_ = os.Mkdir(global.GVA_CONFIG.Zap.Director, os.ModePerm)
 	}
 
-	cores := make([]zapcore.Core, 0, 7)
-	debugLevel := getEncoderCore(zap.DebugLevel)
-	infoLevel := getEncoderCore(zap.InfoLevel)
-	warnLevel := getEncoderCore(zap.WarnLevel)
-	errorLevel := getEncoderCore(zap.ErrorLevel)
-	dPanicLevel := getEncoderCore(zap.DPanicLevel)
-	panicLevel := getEncoderCore(zap.PanicLevel)
-	fatalLevel := getEncoderCore(zap.FatalLevel)
-	switch global.GVA_CONFIG.Zap.Level {
-	case "debug", "DEBUG":
-		cores = append(cores, debugLevel, infoLevel, warnLevel, errorLevel, dPanicLevel, panicLevel, fatalLevel)
-	case "info", "INFO":
-		cores = append(cores, infoLevel, warnLevel, errorLevel, dPanicLevel, panicLevel, fatalLevel)
-	case "warn", "WARN":
-		cores = append(cores, warnLevel, errorLevel, dPanicLevel, panicLevel, fatalLevel)
-	case "error", "ERROR":
-		cores = append(cores, errorLevel, dPanicLevel, panicLevel, fatalLevel)
-	case "dpanic", "DPANIC":
-		cores = append(cores, dPanicLevel, panicLevel, fatalLevel)
-	case "panic", "PANIC":
-		cores = append(cores, panicLevel, fatalLevel)
-	case "fatal", "FATAL":
-		cores = append(cores, panicLevel, fatalLevel)
-	default:
-		cores = append(cores, debugLevel, infoLevel, warnLevel, errorLevel, dPanicLevel, panicLevel, fatalLevel)
-	}
-	logger = zap.New(zapcore.NewTee(cores...), zap.AddCaller())
+	cores := internal.Zap.GetZapCores()
+	logger = zap.New(zapcore.NewTee(cores...))
 
 	if global.GVA_CONFIG.Zap.ShowLine {
 		logger = logger.WithOptions(zap.AddCaller())
 	}
 	return logger
-}
-
-// getEncoderConfig 获取zapcore.EncoderConfig
-// Author [SliverHorn](https://github.com/SliverHorn)
-func getEncoderConfig() (config zapcore.EncoderConfig) {
-	config = zapcore.EncoderConfig{
-		MessageKey:     "message",
-		LevelKey:       "level",
-		TimeKey:        "time",
-		NameKey:        "logger",
-		CallerKey:      "caller",
-		StacktraceKey:  global.GVA_CONFIG.Zap.StacktraceKey,
-		LineEnding:     zapcore.DefaultLineEnding,
-		EncodeLevel:    zapcore.LowercaseLevelEncoder,
-		EncodeTime:     CustomTimeEncoder,
-		EncodeDuration: zapcore.SecondsDurationEncoder,
-		EncodeCaller:   zapcore.FullCallerEncoder,
-	}
-	switch {
-	case global.GVA_CONFIG.Zap.EncodeLevel == "LowercaseLevelEncoder": // 小写编码器(默认)
-		config.EncodeLevel = zapcore.LowercaseLevelEncoder
-	case global.GVA_CONFIG.Zap.EncodeLevel == "LowercaseColorLevelEncoder": // 小写编码器带颜色
-		config.EncodeLevel = zapcore.LowercaseColorLevelEncoder
-	case global.GVA_CONFIG.Zap.EncodeLevel == "CapitalLevelEncoder": // 大写编码器
-		config.EncodeLevel = zapcore.CapitalLevelEncoder
-	case global.GVA_CONFIG.Zap.EncodeLevel == "CapitalColorLevelEncoder": // 大写编码器带颜色
-		config.EncodeLevel = zapcore.CapitalColorLevelEncoder
-	default:
-		config.EncodeLevel = zapcore.LowercaseLevelEncoder
-	}
-	return config
-}
-
-// getEncoder 获取zapcore.Encoder
-// Author [SliverHorn](https://github.com/SliverHorn)
-func getEncoder() zapcore.Encoder {
-	if global.GVA_CONFIG.Zap.Format == "json" {
-		return zapcore.NewJSONEncoder(getEncoderConfig())
-	}
-	return zapcore.NewConsoleEncoder(getEncoderConfig())
-}
-
-// getEncoderCore 获取Encoder的zapcore.Core
-// Author [SliverHorn](https://github.com/SliverHorn)
-func getEncoderCore(level zapcore.Level) (core zapcore.Core) {
-	writer, err := internal.FileRotatelogs.GetWriteSyncer(level.String()) // 使用file-rotatelogs进行日志分割
-	if err != nil {
-		fmt.Printf("Get Write Syncer Failed err:%v", err.Error())
-		return
-	}
-	return zapcore.NewCore(getEncoder(), writer, level)
-}
-
-// CustomTimeEncoder 自定义日志输出时间格式
-// Author [SliverHorn](https://github.com/SliverHorn)
-func CustomTimeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-	enc.AppendString(t.Format(global.GVA_CONFIG.Zap.Prefix + "2006/01/02 - 15:04:05.000"))
 }


### PR DESCRIPTION
- zap日志无法按照等级出现在对应log文件中
- zap.AddCaller()只有在global.GVA_CONFIG.Zap.ShowLine为true才生效
- rotatelogs.ForceNewFile(),取消这个, 这样每次启动不会出现同一天日志级别.1后缀的新文件