### PR TITLE
修复BUG，如果在这里数据库查询出现错误会导致问题

### DIFF
--- a/server/api/v1/system/sys_user.go
+++ b/server/api/v1/system/sys_user.go
@@ -289,6 +289,7 @@ func (b *BaseApi) SetUserInfo(c *gin.Context) {
 		if err != nil {
 			global.GVA_LOG.Error("设置失败!", zap.Error(err))
 			response.FailWithMessage("设置失败", c)
+			return
 		}
 	}
 


### PR DESCRIPTION
如果在这里数据库查询出现错误，err != nil 就会两次返回 出现返回结果为

{"code":7,"data":{},"msg":"设置失败"}{"code":0,"data":{},"msg":"设置成功"}
这种形式，导致vue js无法正确处理返回