### PR TITLE
BUGFIX. VSCode工作区文件配置文件调整，使调试功能兼容最近添加的embed.go

### DIFF
--- a/gin-vue-admin.code-workspace
+++ b/gin-vue-admin.code-workspace
@@ -27,7 +27,7 @@
         "request": "launch",
         "name": "Backend",
         "cwd": "${workspaceFolder:backend}",
-        "program": "${workspaceFolder:backend}/main.go"
+        "program": "${workspaceFolder:backend}/"
       },
       {
         "type": "node",


### PR DESCRIPTION
折磨我两个小时的BUG
手动go build可以
goland可以
VSCODE编译/调试就不行