### PR TITLE
修改密码使用 jwt 中的用户ID，防止越权

### DIFF
--- a/server/api/v1/system/sys_user.go
+++ b/server/api/v1/system/sys_user.go
@@ -138,18 +138,19 @@ func (b *BaseApi) Register(c *gin.Context) {
 // @Summary 用户修改密码
 // @Security ApiKeyAuth
 // @Produce  application/json
-// @Param data body systemReq.ChangePasswordStruct true "用户名, 原密码, 新密码"
+// @Param data body systemReq.ChangePasswordReq true "用户名, 原密码, 新密码"
 // @Success 200 {object} response.Response{msg=string} "用户修改密码"
 // @Router /user/changePassword [post]
 func (b *BaseApi) ChangePassword(c *gin.Context) {
-	var user systemReq.ChangePasswordStruct
-	_ = c.ShouldBindJSON(&user)
-	if err := utils.Verify(user, utils.ChangePasswordVerify); err != nil {
+	var req systemReq.ChangePasswordReq
+	_ = c.ShouldBindJSON(&req)
+	if err := utils.Verify(req, utils.ChangePasswordVerify); err != nil {
 		response.FailWithMessage(err.Error(), c)
 		return
 	}
-	u := &system.SysUser{Username: user.Username, Password: user.Password}
-	if _, err := userService.ChangePassword(u, user.NewPassword); err != nil {
+	uid := utils.GetUserID(c)
+	u := &system.SysUser{GVA_MODEL: global.GVA_MODEL{ID: uid}, Password: req.Password}
+	if _, err := userService.ChangePassword(u, req.NewPassword); err != nil {
 		global.GVA_LOG.Error("修改失败!", zap.Error(err))
 		response.FailWithMessage("修改失败，原密码与当前账户不符", c)
 	} else {
@@ -201,8 +202,7 @@ func (b *BaseApi) SetUserAuthority(c *gin.Context) {
 		return
 	}
 	userID := utils.GetUserID(c)
-	uuid := utils.GetUserUuid(c)
-	if err := userService.SetUserAuthority(userID, uuid, sua.AuthorityId); err != nil {
+	if err := userService.SetUserAuthority(userID, sua.AuthorityId); err != nil {
 		global.GVA_LOG.Error("修改失败!", zap.Error(err))
 		response.FailWithMessage(err.Error(), c)
 	} else {

--- a/server/model/system/request/sys_user.go
+++ b/server/model/system/request/sys_user.go
@@ -22,8 +22,8 @@ type Login struct {
 }
 
 // Modify password structure
-type ChangePasswordStruct struct {
-	Username    string `json:"username"`    // 用户名
+type ChangePasswordReq struct {
+	ID          uint   `json:"-"`           // 从 JWT 中提取 user id，避免越权
 	Password    string `json:"password"`    // 密码
 	NewPassword string `json:"newPassword"` // 新密码
 }

--- a/server/model/system/sys_user_authority.go
+++ b/server/model/system/sys_user_authority.go
@@ -1,10 +1,11 @@
 package system
 
-type SysUseAuthority struct {
+// SysUserAuthority 是 sysUser 和 sysAuthority 的连接表
+type SysUserAuthority struct {
 	SysUserId               uint `gorm:"column:sys_user_id"`
 	SysAuthorityAuthorityId uint `gorm:"column:sys_authority_authority_id"`
 }
 
-func (s *SysUseAuthority) TableName() string {
+func (s *SysUserAuthority) TableName() string {
 	return "sys_user_authority"
 }

--- a/server/service/system/sys_authority.go
+++ b/server/service/system/sys_authority.go
@@ -131,7 +131,7 @@ func (authorityService *AuthorityService) DeleteAuthority(auth *system.SysAuthor
 			return
 		}
 	}
-	err = global.GVA_DB.Delete(&[]system.SysUseAuthority{}, "sys_authority_authority_id = ?", auth.AuthorityId).Error
+	err = global.GVA_DB.Delete(&[]system.SysUserAuthority{}, "sys_authority_authority_id = ?", auth.AuthorityId).Error
 	err = global.GVA_DB.Delete(&[]system.SysAuthorityBtn{}, "authority_id = ?", auth.AuthorityId).Error
 	authorityId := strconv.Itoa(int(auth.AuthorityId))
 	CasbinServiceApp.ClearCasbin(0, authorityId)

--- a/server/utils/verify.go
+++ b/server/utils/verify.go
@@ -14,6 +14,6 @@ var (
 	AuthorityVerify        = Rules{"AuthorityId": {NotEmpty()}, "AuthorityName": {NotEmpty()}}
 	AuthorityIdVerify      = Rules{"AuthorityId": {NotEmpty()}}
 	OldAuthorityVerify     = Rules{"OldAuthorityId": {NotEmpty()}}
-	ChangePasswordVerify   = Rules{"Username": {NotEmpty()}, "Password": {NotEmpty()}, "NewPassword": {NotEmpty()}}
+	ChangePasswordVerify   = Rules{"Password": {NotEmpty()}, "NewPassword": {NotEmpty()}}
 	SetUserAuthorityVerify = Rules{"AuthorityId": {NotEmpty()}}
 )

--- a/web/src/view/person/person.vue
+++ b/web/src/view/person/person.vue
@@ -274,7 +274,6 @@ const savePassword = async() => {
   modifyPwdForm.value.validate((valid) => {
     if (valid) {
       changePassword({
-        username: userStore.userInfo.userName,
         password: pwdModify.value.password,
         newPassword: pwdModify.value.newPassword,
       }).then((res) => {


### PR DESCRIPTION
- 修改密码（`ChangePassword()` ）改为使用 id 查询
- 从jwt中获取目标用户id，而非不校验地使用 `username` （任意登录用户只要知道另一个用户的密码都可以改他的密码）
- 修了一个命名错误