### PR TITLE
fix : previewCodeDialg.vue fix "the requested module does not provide…

### DIFF
--- a/web/src/view/systemTools/autoCode/component/previewCodeDialg.vue
+++ b/web/src/view/systemTools/autoCode/component/previewCodeDialg.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup>
-import marked from 'marked'
+import { marked } from 'marked'
 import hljs from 'highlight.js'
 import 'highlight.js/styles/atelier-plateau-light.css'
 import { ElMessage } from 'element-plus'


### PR DESCRIPTION
… an export named 'default'"

v2.5.3 代码生成器链接打开报错“Uncaught (in promise) SyntaxError: The requested module '/node_modules/.vite/deps/marked.js?v=6a7f6b69' does not provide an export named 'default' (at previewCodeDialg.vue:12:8)”。"marked": "^4.0.18", "vue": "^3.2.27"