### PR TITLE
优化角色管理中菜单和api管理的确定按钮，固定在右上角，更容易操作，每次修改完不需要拉到最上面再确定

### DIFF
--- a/web/src/style/button.scss
+++ b/web/src/style/button.scss
@@ -1,0 +1,5 @@
+.sticky-button {
+  position: sticky;
+  top: 2px;
+  z-index: 2;
+}

--- a/web/src/style/button.scss
+++ b/web/src/style/button.scss
@@ -3,3 +3,6 @@
   top: 2px;
   z-index: 2;
 }
+.fitler{
+  width: 60%;
+}

--- a/web/src/view/superAdmin/authority/components/apis.vue
+++ b/web/src/view/superAdmin/authority/components/apis.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <div class="clearfix sticky-button">
+      <el-input class="fitler" v-model="filterText" placeholder="筛选" />
       <el-button class="fl-right" size="small" type="primary" @click="authApiEnter">确 定</el-button>
     </div>
     <el-tree
@@ -12,6 +13,7 @@
       highlight-current
       node-key="onlyId"
       show-checkbox
+      :filter-node-method="filterNode"
       @check="nodeChange"
     />
   </div>
@@ -25,7 +27,7 @@ export default {
 <script setup>
 import { getAllApis } from '@/api/api'
 import { UpdateCasbin, getPolicyPathByAuthorityId } from '@/api/casbin'
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { ElMessage } from 'element-plus'
 const props = defineProps({
   row: {
@@ -40,7 +42,7 @@ const apiDefaultProps = ref({
   children: 'children',
   label: 'description'
 })
-
+const filterText = ref('')
 const apiTreeData = ref([])
 const apiTreeIds = ref([])
 const activeUserId = ref('')
@@ -120,7 +122,16 @@ defineExpose({
   enterAndNext
 })
 
+const filterNode = (value, data) => {
+  if (!value) return true
+  return data.description.indexOf(value) !== -1
+}
+watch(filterText, (val) => {
+  apiTree.value.filter(val)
+})
+
 </script>
+
 <style lang="scss" scoped>
 @import "@/style/button.scss";
 </style>

--- a/web/src/view/superAdmin/authority/components/apis.vue
+++ b/web/src/view/superAdmin/authority/components/apis.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="clearfix">
+    <div class="clearfix sticky-button">
       <el-button class="fl-right" size="small" type="primary" @click="authApiEnter">确 定</el-button>
     </div>
     <el-tree
@@ -121,3 +121,6 @@ defineExpose({
 })
 
 </script>
+<style lang="scss" scoped>
+@import "@/style/button.scss";
+</style>

--- a/web/src/view/superAdmin/authority/components/menus.vue
+++ b/web/src/view/superAdmin/authority/components/menus.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <div class="clearfix sticky-button">
+      <el-input class="fitler" v-model="filterText" placeholder="筛选" />
       <el-button class="fl-right" size="small" type="primary" @click="relation">确 定</el-button>
     </div>
     <el-tree
@@ -13,6 +14,7 @@
       node-key="ID"
       show-checkbox
       @check="nodeChange"
+      :filter-node-method="filterNode"
     >
       <template #default="{ node , data }">
         <span class="custom-tree-node">
@@ -70,8 +72,9 @@ import {
   updateAuthority
 } from '@/api/authority'
 import { getAuthorityBtnApi, setAuthorityBtnApi } from '@/api/authorityBtn'
-import { nextTick, ref } from 'vue'
+import { nextTick, ref, watch } from 'vue'
 import { ElMessage } from 'element-plus'
+
 const props = defineProps({
   row: {
     default: function() {
@@ -82,7 +85,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['changeRow'])
-
+const filterText = ref('')
 const menuTreeData = ref([])
 const menuTreeIds = ref([])
 const needConfirm = ref(false)
@@ -192,6 +195,16 @@ const enterDialog = async() => {
   }
 }
 
+const filterNode = (value, data) => {
+  if (!value) return true
+  // console.log(data.mate.title)
+  return data.meta.title.indexOf(value) !== -1
+}
+
+watch(filterText, (val) => {
+  menuTree.value.filter(val)
+})
+
 </script>
 
 <script>
@@ -202,10 +215,10 @@ export default {
 </script>
 
 <style lang="scss" scope>
+@import "@/style/button.scss";
 .custom-tree-node{
   span+span{
     margin-left: 12px;
   }
 }
-@import "@/style/button.scss";
 </style>

--- a/web/src/view/superAdmin/authority/components/menus.vue
+++ b/web/src/view/superAdmin/authority/components/menus.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="clearfix">
+    <div class="clearfix sticky-button">
       <el-button class="fl-right" size="small" type="primary" @click="relation">确 定</el-button>
     </div>
     <el-tree
@@ -207,4 +207,5 @@ export default {
     margin-left: 12px;
   }
 }
+@import "@/style/button.scss";
 </style>


### PR DESCRIPTION
优化角色管理中菜单和api管理的确定按钮，固定在右上角，更容易操作，每次修改完不需要拉到最上面再确定