### PR TITLE
zap支持链路跟踪，增加traceid

### DIFF
--- a/.github/workflows/docker-cicd.yaml
+++ b/.github/workflows/docker-cicd.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Sed Config
         shell: bash
         run: |
-          sed  -i 51c"\        && yarn install && yarn build" Makefile
+          sed  -i 56c"\        && yarn install && yarn build" Makefile
           make image TAGS_OPT="latest"
           sed -i 's#./entrypoint.sh"#./entrypoint.sh","actions"#g' deploy/docker/Dockerfile
           sed -i "s#COPY build/ /usr/share/nginx/html/#COPY . /opt/gva#g" deploy/docker/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ TAGS_OPT            = latest
 else
 endif
 
+ifeq ($(PLUGIN),)
+PLUGIN            = email
+else
+endif
+
 #容器环境前后端共同打包
 build: build-web build-server
 	docker run --name build-local --rm -v $(shell pwd):/go/src/${PROJECT_NAME} -w /go/src/${PROJECT_NAME} ${BUILD_IMAGE_SERVER} make build-local
@@ -64,3 +69,10 @@ image: build
 #尝鲜版
 images: build build-image-web build-image-server
 	docker build -t ${REPOSITORY}/all:${TAGS_OPT} -f deploy/docker/Dockerfile .
+	
+#插件快捷打包： make plugin PLUGIN="这里是插件文件夹名称,默认为email"
+plugin:
+	if [ -d ".plugin" ];then rm -rf .plugin ; else echo "OK!"; fi && mkdir -p .plugin/${PLUGIN}/{server/plugin,web/plugin} \
+	&& if [ -d "server/plugin/${PLUGIN}" ];then cp -r server/plugin/${PLUGIN} .plugin/${PLUGIN}/server/plugin/ ; else echo "OK!"; fi \
+	&& if [ -d "web/src/plugin/${PLUGIN}" ];then cp -r web/src/plugin/${PLUGIN} .plugin/${PLUGIN}/web/plugin/ ; else echo "OK!"; fi \
+	&& cd .plugin && zip -r ${PLUGIN}.zip ${PLUGIN} && mv ${PLUGIN}.zip ../ && cd ..

--- a/README-en.md
+++ b/README-en.md
@@ -25,7 +25,7 @@ English | [简体中文](./README.md)
 
 [From the environment to the deployment of teaching videos](https://www.bilibili.com/video/BV1fV411y7dT)
 
-[Development Steps](https://www.gin-vue-admin.com/docs/help) (Contributor:  <a href="https://github.com/LLemonGreen">LLemonGreen</a> And <a href="https://github.com/fkk0509">Fann</a>)
+[Development Steps](https://www.gin-vue-admin.com/guide/start-quickly/env.html) (Contributor:  <a href="https://github.com/LLemonGreen">LLemonGreen</a> And <a href="https://github.com/fkk0509">Fann</a>)
 
 ## 1. Basic Introduction
 
@@ -297,7 +297,7 @@ swag init
 |  :---:  | 
 | <img width="150" src="http://qmplusimg.henrongyi.top/qrjjz.png"> 
 
-#### [About Us](https://www.gin-vue-admin.com/about/)
+#### [About Us](https://www.gin-vue-admin.com/about/join.html)
 
 ## 8. Contributors
 
@@ -309,7 +309,7 @@ Thank you for considering your contribution to gin-vue-admin!
 
 ## 9. Donate
 
-If you find this project useful, you can buy author a glass of juice :tropical_drink: [here](https://www.gin-vue-admin.com/docs/coffee)
+If you find this project useful, you can buy author a glass of juice :tropical_drink: [here](https://www.gin-vue-admin.com/coffee/index.html)
 
 ## 10. Commercial considerations
 

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ swag init
 
 添加微信，备注"加入gin-vue-admin交流群"
 
-### [关于我们](https://www.gin-vue-admin.com/about/)
+### [关于我们](https://www.gin-vue-admin.com/about/join.html)
 
 ## 8. 贡献者
 
@@ -382,7 +382,7 @@ swag init
 
 ## 9. 捐赠
 
-如果你觉得这个项目对你有帮助，你可以请作者喝饮料 :tropical_drink: [点我](https://www.gin-vue-admin.com/docs/coffee)
+如果你觉得这个项目对你有帮助，你可以请作者喝饮料 :tropical_drink: [点我](https://www.gin-vue-admin.com/coffee/index.html)
 
 ## 10. 友情链接
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ swag init
 
 - 前端：用基于 [Vue](https://vuejs.org) 的 [Element](https://github.com/ElemeFE/element) 构建基础页面。
 - 后端：用 [Gin](https://gin-gonic.com/) 快速搭建基础restful风格API，[Gin](https://gin-gonic.com/) 是一个go语言编写的Web框架。
-- 数据库：采用`MySql`(5.6.44)版本，使用 [gorm](http://gorm.cn) 实现对数据库的基本操作。
+- 数据库：采用`MySql` > (5.7) 版本 数据库引擎 InnoDB，使用 [gorm](http://gorm.cn) 实现对数据库的基本操作。
 - 缓存：使用`Redis`实现记录当前活跃用户的`jwt`令牌并实现多点登录限制。
 - API文档：使用`Swagger`构建自动化文档。
 - 配置文件：使用 [fsnotify](https://github.com/fsnotify/fsnotify) 和 [viper](https://github.com/spf13/viper) 实现`yaml`格式的配置文件。

--- a/deploy/docker-compose/docker-compose-dev.yaml
+++ b/deploy/docker-compose/docker-compose-dev.yaml
@@ -28,7 +28,7 @@ services:
     #command: bash -c "yarn config set registry https://registry.npm.taobao.org --global && yarn install && yarn serve"
     command: bash -c "yarn install && yarn serve"
     volumes:
-      - ./web:/web
+      - ../../web:/web
     networks:
       network:
         ipv4_address: 177.7.0.11
@@ -44,7 +44,7 @@ services:
       - mysql
       - redis
     volumes:
-      - ./server:/server
+      - ../../server:/server
     working_dir: /server    # 如果docker 设置了workdir 则此处不需要设置 
     command: bash -c "go env -w GOPROXY=https://goproxy.cn,direct && go mod tidy && go run main.go"
     links:

--- a/deploy/docker-compose/docker-compose.yaml
+++ b/deploy/docker-compose/docker-compose.yaml
@@ -16,7 +16,7 @@ volumes:
 services:
   web:
     build:
-      context: ./web
+      context: ../../web
       dockerfile: ./Dockerfile
     container_name: gva-web
     restart: always
@@ -31,7 +31,7 @@ services:
 
   server:
     build:
-      context: ./server
+      context: ../../server
       dockerfile: ./Dockerfile
     container_name: gva-server
     restart: always

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -6,15 +6,17 @@ jwt:
   expires-time: 604800
   buffer-time: 86400
   issuer: 'qmPlus'
+
 # zap logger configuration
 zap:
   level: 'info'
-  format: 'console'
   prefix: '[github.com/flipped-aurora/gin-vue-admin/server]'
+  format: 'console'
   director: 'log'
-  show-line: true
   encode-level: 'LowercaseColorLevelEncoder'
   stacktrace-key: 'stacktrace'
+  max-age: 30 # 默认日志留存默认以天为单位
+  show-line: true
   log-in-console: true
 
 # redis configuration
@@ -32,10 +34,6 @@ email:
   is-ssl: true
   secret: 'xxx'
   nickname: 'test'
-
-# casbin configuration
-casbin:
-  model-path: './resource/rbac_model.conf'
 
 # system configuration
 system:
@@ -57,7 +55,7 @@ captcha:
   img-height: 80
 
 # mysql connect configuration
-# 未初始化之前请勿手动修改数据库信息！！！如果一定要手动初始化请看（https://www.github.com/flipped-aurora/gin-vue-admin/server.com/docs/first）
+# 未初始化之前请勿手动修改数据库信息！！！如果一定要手动初始化请看（https://gin-vue-admin.com/docs/first_master）
 mysql:
   path: ''
   port: ''
@@ -71,7 +69,7 @@ mysql:
   log-zap: false
 
 # pgsql connect configuration
-# 未初始化之前请勿手动修改数据库信息！！！如果一定要手动初始化请看（https://www.github.com/flipped-aurora/gin-vue-admin/server.com/docs/first）
+# 未初始化之前请勿手动修改数据库信息！！！如果一定要手动初始化请看（https://gin-vue-admin.com/docs/first_master）
 pgsql:
   path: ''
   port: ''
@@ -102,7 +100,8 @@ db-list:
 
 # local configuration
 local:
-  path: 'uploads/file'
+  path: 'uploads/file' # 访问路径
+  store-path: 'uploads/file' # 存储路径
 
 # autocode configuration
 autocode:
@@ -111,12 +110,13 @@ autocode:
   # 请不要手动配置,他会在项目加载的时候识别出根路径
   root: ""
   server: /server
-  server-api: /api/v1/autocode
+  server-plug: /plugin/%s
+  server-api: /api/v1/%s
   server-initialize: /initialize
-  server-model: /model/autocode
-  server-request: /model/autocode/request/
-  server-router: /router/autocode
-  server-service: /service/autocode
+  server-model: /model/%s
+  server-request: /model/%s/request/
+  server-router: /router/%s
+  server-service: /service/%s
   web: /web/src
   web-api: /api
   web-form: /view

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -1,16 +1,117 @@
-aliyun-oss:
-  endpoint: yourEndpoint
-  access-key-id: yourAccessKeyId
-  access-key-secret: yourAccessKeySecret
-  bucket-name: yourBucketName
-  bucket-url: yourBucketUrl
-  base-path: yourBasePath
+# github.com/flipped-aurora/gin-vue-admin/server Global Configuration
+
+# jwt configuration
+jwt:
+  signing-key: 'qmPlus'
+  expires-time: 604800
+  buffer-time: 86400
+  issuer: 'qmPlus'
+
+# zap logger configuration
+zap:
+  level: 'info'
+  prefix: '[github.com/flipped-aurora/gin-vue-admin/server]'
+  format: 'console'
+  director: 'log'
+  encode-level: 'LowercaseColorLevelEncoder'
+  stacktrace-key: 'stacktrace'
+  max-age: 30 # 默认日志留存默认以天为单位
+  show-line: true
+  log-in-console: true
+
+# redis configuration
+redis:
+  db: 0
+  addr: '127.0.0.1:6379'
+  password: ''
+
+# email configuration
+email:
+  to: 'xxx@qq.com'
+  port: 465
+  from: 'xxx@163.com'
+  host: 'smtp.163.com'
+  is-ssl: true
+  secret: 'xxx'
+  nickname: 'test'
+
+# system configuration
+system:
+  env: 'public'  # Change to "develop" to skip authentication for development mode
+  addr: 8888
+  db-type: 'mysql'
+  oss-type: 'local'    # 控制oss选择走本地还是 七牛等其他仓 自行增加其他oss仓可以在 server/utils/upload/upload.go 中 NewOss函数配置
+  use-redis: false     # 使用redis
+  use-multipoint: false
+  # IP限制次数 一个小时15000次
+  iplimit-count: 15000
+  #  IP限制一个小时
+  iplimit-time: 3600
+
+# captcha configuration
+captcha:
+  key-long: 6
+  img-width: 240
+  img-height: 80
+
+# mysql connect configuration
+# 未初始化之前请勿手动修改数据库信息！！！如果一定要手动初始化请看（https://gin-vue-admin.com/docs/first_master）
+mysql:
+  path: ''
+  port: ''
+  config: ''
+  db-name: ''
+  username: ''
+  password: ''
+  max-idle-conns: 10
+  max-open-conns: 100
+  log-mode: ""
+  log-zap: false
+
+# pgsql connect configuration
+# 未初始化之前请勿手动修改数据库信息！！！如果一定要手动初始化请看（https://gin-vue-admin.com/docs/first_master）
+pgsql:
+  path: ''
+  port: ''
+  config: ''
+  db-name: ''
+  username: ''
+  password: ''
+  max-idle-conns: 10
+  max-open-conns: 100
+  log-mode: ""
+  log-zap: false
+
+db-list:
+  - disabled: true # 是否启用
+    type: "" # 数据库的类型,目前支持mysql、pgsql
+    alias-name: "" # 数据库的名称,注意: alias-name 需要在db-list中唯一
+    path: ''
+    port: ''
+    config: ''
+    db-name: ''
+    username: ''
+    password: ''
+    max-idle-conns: 10
+    max-open-conns: 100
+    log-mode: ""
+    log-zap: false
+
+
+# local configuration
+local:
+  path: 'uploads/file' # 访问路径
+  store-path: 'uploads/file' # 存储路径
+
+# autocode configuration
 autocode:
   transfer-restart: true
-  root: /Users/feixuanyu/Documents/code/goProject/masonFeiGva
+  # root 自动适配项目根目录
+  # 请不要手动配置,他会在项目加载的时候识别出根路径
+  root: ""
   server: /server
-  server-api: /api/v1/%s
   server-plug: /plugin/%s
+  server-api: /api/v1/%s
   server-initialize: /initialize
   server-model: /model/%s
   server-request: /model/%s/request/
@@ -20,141 +121,83 @@ autocode:
   web-api: /api
   web-form: /view
   web-table: /view
+
+# qiniu configuration (请自行七牛申请对应的 公钥 私钥 bucket 和 域名地址)
+qiniu:
+  zone: 'ZoneHuaDong'
+  bucket: ''
+  img-path: ''
+  use-https: false
+  access-key: ''
+  secret-key: ''
+  use-cdn-domains: false
+
+# aliyun oss configuration
+aliyun-oss:
+  endpoint: 'yourEndpoint'
+  access-key-id: 'yourAccessKeyId'
+  access-key-secret: 'yourAccessKeySecret'
+  bucket-name: 'yourBucketName'
+  bucket-url: 'yourBucketUrl'
+  base-path: 'yourBasePath'
+
+# tencent cos configuration
+tencent-cos:
+  bucket: 'xxxxx-10005608'
+  region: 'ap-shanghai'
+  secret-id: 'xxxxxxxx'
+  secret-key: 'xxxxxxxx'
+  base-url: 'https://gin.vue.admin'
+  path-prefix: 'github.com/flipped-aurora/gin-vue-admin/server'
+
+# aws s3 configuration (minio compatible)
 aws-s3:
   bucket: xxxxx-10005608
   region: ap-shanghai
-  endpoint: ""
+  endpoint: ''
   s3-force-path-style: false
   disable-ssl: false
   secret-id: xxxxxxxx
   secret-key: xxxxxxxx
   base-url: https://gin.vue.admin
   path-prefix: github.com/flipped-aurora/gin-vue-admin/server
-captcha:
-  key-long: 6
-  img-width: 240
-  img-height: 80
-cors:
-  mode: whitelist
-  whitelist:
-  - allow-origin: example1.com
-    allow-methods: GET, POST
-    allow-headers: content-type
-    expose-headers: Content-Length, Access-Control-Allow-Origin, Access-Control-Allow-Headers,
-      Content-Type
-    allow-credentials: true
-  - allow-origin: example2.com
-    allow-methods: GET, POST
-    allow-headers: content-type
-    expose-headers: Content-Length, Access-Control-Allow-Origin, Access-Control-Allow-Headers,
-      Content-Type
-    allow-credentials: true
-db-list:
-- disable: false
-  type: ""
-  alias-name: ""
-  path: ""
-  port: ""
-  config: ""
-  db-name: ""
-  username: ""
-  password: ""
-  max-idle-conns: 10
-  max-open-conns: 100
-  log-mode: ""
-  log-zap: false
-email:
-  to: xxx@qq.com
-  port: 465
-  from: xxx@163.com
-  host: smtp.163.com
-  is-ssl: true
-  secret: xxx
-  nickname: test
-excel:
-  dir: ./resource/excel/
+
+# huawei obs configuration
 hua-wei-obs:
-  path: you-path
-  bucket: you-bucket
-  endpoint: you-endpoint
-  access-key: you-access-key
-  secret-key: you-secret-key
-jwt:
-  signing-key: 6e3d0851-fa2a-4e7d-904c-cfa60081c8b3
-  expires-time: 604800
-  buffer-time: 86400
-  issuer: qmPlus
-local:
-  path: uploads/file
-  store-path: uploads/file
-mysql:
-  path: 127.0.0.1
-  port: "3306"
-  config: charset=utf8mb4&parseTime=True&loc=Local
-  db-name: gva
-  username: root
-  password: "123456"
-  max-idle-conns: 10
-  max-open-conns: 100
-  log-mode: error
-  log-zap: false
-pgsql:
-  path: ""
-  port: ""
-  config: ""
-  db-name: ""
-  username: ""
-  password: ""
-  max-idle-conns: 10
-  max-open-conns: 100
-  log-mode: ""
-  log-zap: false
-qiniu:
-  zone: ZoneHuaDong
-  bucket: ""
-  img-path: ""
-  use-https: false
-  access-key: ""
-  secret-key: ""
-  use-cdn-domains: false
-redis:
-  db: 0
-  addr: 127.0.0.1:6379
-  password: ""
-system:
-  env: public
-  addr: 8888
-  db-type: mysql
-  oss-type: local
-  use-multipoint: false
-  use-redis: false
-  iplimit-count: 15000
-  iplimit-time: 3600
-tencent-cos:
-  bucket: xxxxx-10005608
-  region: ap-shanghai
-  secret-id: xxxxxxxx
-  secret-key: xxxxxxxx
-  base-url: https://gin.vue.admin
-  path-prefix: github.com/flipped-aurora/gin-vue-admin/server
-timer:
+  path: 'you-path'
+  bucket: 'you-bucket'
+  endpoint: 'you-endpoint'
+  access-key: 'you-access-key'
+  secret-key: 'you-secret-key'
+
+# excel configuration
+excel:
+  dir: './resource/excel/'
+
+# timer task db clear table
+Timer:
   start: true
-  spec: '@daily'
-  with_seconds: false
+  spec: "@daily"  # 定时任务详细配置参考 https://pkg.go.dev/github.com/robfig/cron/v3
   detail:
-  - tableName: sys_operation_records
-    compareField: created_at
-    interval: 2160h
-  - tableName: jwt_blacklists
-    compareField: created_at
-    interval: 168h
-zap:
-  level: info
-  prefix: '[github.com/flipped-aurora/gin-vue-admin/server]'
-  format: console
-  director: log
-  encode-level: LowercaseColorLevelEncoder
-  stacktrace-key: stacktrace
-  max-age: 30
-  show-line: true
-  log-in-console: true
+    - tableName: "sys_operation_records"
+      compareField: "created_at"
+      interval: "2160h"
+    - tableName: "jwt_blacklists"
+      compareField: "created_at"
+      interval: "168h"
+
+# 跨域配置
+# 需要配合 server/initialize/router.go#L32 使用
+cors:
+  mode: whitelist # 放行模式: allow-all, 放行全部; whitelist, 白名单模式, 来自白名单内域名的请求添加 cors 头; strict-whitelist 严格白名单模式, 白名单外的请求一律拒绝
+  whitelist:
+    - allow-origin: example1.com
+      allow-headers: content-type
+      allow-methods: GET, POST
+      expose-headers: Content-Length, Access-Control-Allow-Origin, Access-Control-Allow-Headers, Content-Type
+      allow-credentials: true # 布尔值
+    - allow-origin: example2.com
+      allow-headers: content-type
+      allow-methods: GET, POST
+      expose-headers: Content-Length, Access-Control-Allow-Origin, Access-Control-Allow-Headers, Content-Type
+      allow-credentials: true # 布尔值

--- a/server/core/internal/zap.go
+++ b/server/core/internal/zap.go
@@ -54,7 +54,7 @@ func (z *_zap) GetEncoderCore(l zapcore.Level, level zap.LevelEnablerFunc) zapco
 // CustomTimeEncoder 自定义日志输出时间格式
 // Author [SliverHorn](https://github.com/SliverHorn)
 func (z *_zap) CustomTimeEncoder(t time.Time, encoder zapcore.PrimitiveArrayEncoder) {
-	encoder.AppendString(t.Format(global.GVA_CONFIG.Zap.Prefix + "2006/01/02 - 15:04:05.000"))
+	encoder.AppendString(global.GVA_CONFIG.Zap.Prefix + t.Format("2006/01/02 - 15:04:05.000"))
 }
 
 // GetZapCores 根据配置文件的Level获取 []zapcore.Core

--- a/server/core/zap.go
+++ b/server/core/zap.go
@@ -42,6 +42,6 @@ func ZapWrapper() (logger *log.LogWrapper) {
 	if global.GVA_CONFIG.Zap.ShowLine {
 		zapLogger = zapLogger.WithOptions(zap.AddCaller())
 	}
-	log.EcoLog = &log.LogWrapper{ZapLogger: zapLogger}
-	return log.EcoLog
+	log.GvaLog = &log.LogWrapper{ZapLogger: zapLogger}
+	return log.GvaLog
 }

--- a/server/core/zap.go
+++ b/server/core/zap.go
@@ -40,7 +40,8 @@ func ZapWrapper() (logger *log.LogWrapper) {
 	zapLogger = zap.New(zapcore.NewTee(cores...))
 
 	if global.GVA_CONFIG.Zap.ShowLine {
-		zapLogger = zapLogger.WithOptions(zap.AddCaller())
+		// 跳过1层 caller 调用栈,避免调用包装类造成行号都是一样的
+		zapLogger = zapLogger.WithOptions(zap.AddCaller(), zap.AddCallerSkip(1))
 	}
 	log.GvaLog = &log.LogWrapper{ZapLogger: zapLogger}
 	return log.GvaLog

--- a/server/initialize/router.go
+++ b/server/initialize/router.go
@@ -14,14 +14,9 @@ import (
 // 初始化总路由
 func Routers() *gin.Engine {
 	Router := gin.Default()
-	// 开启以下两行注释代码，则会重新生成一个带有记录traceId的中间件，在每个http的日志中打印出来traceId
+	// 开启以下两行注释代码，则会重新生成一个带有记录trace信息的中间件，在每个http的日志中打印出来trace信息
 	//Router := gin.New()
-	//Router.Use(middleware.AddTraceId())
-	//Router.Use(middleware.DefaultLogger())
-	//traceId := gin.Context.get   .GetHeader("traceId")
-	//if traceId == "" {
-	//	traceId = uuid.New().String()
-	//}
+	//Router.Use(middleware.AddTraceInfo())
 	systemRouter := router.RouterGroupApp.System
 	exampleRouter := router.RouterGroupApp.Example
 	// 如果想要不使用nginx代理前端网页，可以修改 web/.env.production 下的

--- a/server/middleware/logger.go
+++ b/server/middleware/logger.go
@@ -86,17 +86,27 @@ func DefaultLogger() gin.HandlerFunc {
 	}.SetLoggerMiddleware()
 }
 
-//func AddTraceId() gin.HandlerFunc {
-//	return func(g *gin.Context) {
-//		traceId := g.GetHeader("traceId")
-//		if traceId == "" {
-//			traceId = uuid.New().String()
-//		}
-//		g.Request = g.Request.WithContext(context.WithValue(g, "traceId", traceId))
-//		//global.GVA_LOG.WithOptions()
-//		//global.GVA_LOG = global.GVA_LOG.With(zap.Any("traceId", traceId))
-//		//global.GVA_LOG = global.GVA_LOG.With(
-//		global.GVA_LOG = core.Zap().With(zap.Any("traceId", traceId))
-//		g.Next()
+//func AddTraceInfo() gin.HandlerFunc {
+//	return func(c *gin.Context) {
+//		start := time.Now()
+//		uuidStr := strings.ReplaceAll(uuid.New().String(), "-", "")
+//		path := c.Request.URL.Path
+//		userId := c.GetInt("user_id")
+//		ctx := context.WithValue(context.Background(), common.TraceKey, &common.Trace{TraceId: uuidStr, Caller: path, UserId: userId})
+//		c.Set(common.TraceCtx, ctx)
+//
+//		c.Next()
+//		cost := time.Since(start)
+//		global.GVA_LOG.Info("_com_request_info",
+//			zap.Int("Status", c.Writer.Status()),
+//			zap.String("Method", c.Request.Method),
+//			zap.String("IP", c.ClientIP()),
+//			zap.String("Path", path),
+//			zap.String("TraceId", uuidStr),
+//			zap.Int("UserId", userId),
+//			zap.String("query", c.Request.URL.RawQuery),
+//			zap.String("UserAgent", c.Request.UserAgent()),
+//			zap.Duration("Cost", cost),
+//		)
 //	}
 //}

--- a/web/src/view/login/index.vue
+++ b/web/src/view/login/index.vue
@@ -141,9 +141,13 @@ const checkPassword = (rule, value, callback) => {
 
 // 获取验证码
 const loginVerify = () => {
-  captcha({}).then((ele) => {
-    rules.captcha[1].max = ele.data.captchaLength
-    rules.captcha[1].min = ele.data.captchaLength
+  captcha({}).then(async(ele) => {
+    rules.captcha.push({
+      max: ele.data.captchaLength,
+      min: ele.data.captchaLength,
+      message: `请输入${ele.data.captchaLength}位验证码`,
+      trigger: 'blur',
+    })
     picPath.value = ele.data.picPath
     loginFormData.captchaId = ele.data.captchaId
   })
@@ -168,7 +172,6 @@ const rules = reactive({
   username: [{ validator: checkUsername, trigger: 'blur' }],
   password: [{ validator: checkPassword, trigger: 'blur' }],
   captcha: [
-    { required: true, message: '请输入验证码', trigger: 'blur' },
     {
       message: '验证码格式不正确',
       trigger: 'blur',


### PR DESCRIPTION

1.在common的包下面增加Trace的数据结构，例如trace_id等字段都包含在此结构体中。

代码文件路径：/server/model/common/trace.go

2.定义AddTraceInfo中间件
在middleware中增加AddTraceInfo中间件，这个中间件定义了每个打进来的请求的日志的格式，同时将关键的trace信息保存在header中。

代码文件路径：/server/middleware/logger.go

3.使用中间件
Router := gin.New()
Router.Use(middleware.AddTraceInfo())

​ 这样保证打进来的请求都在header中有对应的trace信息。

​ 代码文件路径：/server/initialize/router.go

4.创建增加了自定义trace信息的zap包装方法，并且实现可以打印trace信息的方法
此方法中实现了DebugF(), InfoF(),WarnF(),ErrorF(),FatalF()支持打印trace信息的方法，剩下四个方法不支持trace信息打印。

代码文件路径：/server/utils/log/log_wrapper.go

5.项目启动时初始化zap的包装方法
项目启动的时候，初始化全局变量global.GVA_LOG 为Zap的包装方法，注意global.GVA_LOG的类型为*log.LogWrapper

代码文件路径：

/server/main.go

/server/global/global.go

6.在需要打印的地方调用可以打印trace信息的方法，使用方式为
global.GVA_LOG.InfoF(common.GetTraceCtx(c), "创建ota记录日志!")
​ 需要通过common.GetTraceCtx(c)获取到header中的trace信息，这样才会打印出携带trace信息。如果需要在service等方法中使用traceId的打印方法，需要传递此值common.GetTraceCtx(c)。
