### PR TITLE
email.go: 修复邮箱测试收件人错误bug

### DIFF
--- a/server/plugin/email/utils/email.go
+++ b/server/plugin/email/utils/email.go
@@ -43,7 +43,7 @@ func ErrorToEmail(subject string, body string) error {
 //@return: error
 
 func EmailTest(subject string, body string) error {
-	to := []string{global.GlobalConfig.From}
+	to := []string{global.GlobalConfig.To}
 	return send(to, subject, body)
 }
 


### PR DESCRIPTION
邮箱插件中的测试邮件函数 `EmailTest` 中收件人写成了发件人