### PR TITLE
格式化前后端代码

### DIFF
--- a/server/api/v1/enter.go
+++ b/server/api/v1/enter.go
@@ -6,8 +6,8 @@ import (
 )
 
 type ApiGroup struct {
-	SystemApiGroup   system.ApiGroup
-	ExampleApiGroup  example.ApiGroup
+	SystemApiGroup  system.ApiGroup
+	ExampleApiGroup example.ApiGroup
 }
 
 var ApiGroupApp = new(ApiGroup)

--- a/server/api/v1/example/exa_excel.go
+++ b/server/api/v1/example/exa_excel.go
@@ -1,13 +1,14 @@
 package example
 
 import (
+	"os"
+	"strings"
+
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/common/response"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/example"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
-	"os"
-	"strings"
 )
 
 type ExcelApi struct{}

--- a/server/api/v1/system/sys_auto_code.go
+++ b/server/api/v1/system/sys_auto_code.go
@@ -3,15 +3,16 @@ package system
 import (
 	"errors"
 	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/common/response"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/system"
 	"github.com/flipped-aurora/gin-vue-admin/server/utils"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-	"net/url"
-	"os"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -79,7 +80,7 @@ func (autoApi *AutoCodeApi) CreateTemp(c *gin.Context) {
 	a.PackageT = caser.String(a.Package)
 	err := autoCodeService.CreateTemp(a, apiIds...)
 	if err != nil {
-		if errors.Is(err, system.AutoMoveErr) {
+		if errors.Is(err, system.ErrAutoMove) {
 			c.Writer.Header().Add("success", "true")
 			c.Writer.Header().Add("msg", url.QueryEscape(err.Error()))
 		} else {

--- a/server/api/v1/system/sys_initdb.go
+++ b/server/api/v1/system/sys_initdb.go
@@ -56,5 +56,4 @@ func (i *DBApi) CheckDB(c *gin.Context) {
 	}
 	global.GVA_LOG.Info(message)
 	response.OkWithDetailed(gin.H{"needInit": needInit}, message, c)
-	return
 }

--- a/server/initialize/internal/gorm.go
+++ b/server/initialize/internal/gorm.go
@@ -31,10 +31,8 @@ func (g *_gorm) Config() *gorm.Config {
 	switch global.GVA_CONFIG.System.DbType {
 	case "mysql":
 		logMode = &global.GVA_CONFIG.Mysql
-		break
 	case "pgsql":
 		logMode = &global.GVA_CONFIG.Pgsql
-		break
 	default:
 		logMode = &global.GVA_CONFIG.Mysql
 	}

--- a/server/model/system/request/sys_auto_history.go
+++ b/server/model/system/request/sys_auto_history.go
@@ -8,6 +8,6 @@ type SysAutoHistory struct {
 
 // GetById Find by id structure
 type RollBack struct {
-	ID int `json:"id" form:"id"` // 主键ID
+	ID          int  `json:"id" form:"id"`                   // 主键ID
 	DeleteTable bool `json:"deleteTable" form:"deleteTable"` // 是否删除表
 }

--- a/server/model/system/sys_auto_code.go
+++ b/server/model/system/sys_auto_code.go
@@ -2,9 +2,10 @@ package system
 
 import (
 	"errors"
-	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"go/token"
 	"strings"
+
+	"github.com/flipped-aurora/gin-vue-admin/server/global"
 )
 
 // AutoCodeStruct 初始版本自动化代码工具
@@ -61,7 +62,7 @@ type Field struct {
 	Clearable       bool   `json:"clearable"`       // 是否可清空
 }
 
-var AutoMoveErr error = errors.New("创建代码成功并移动文件成功")
+var ErrAutoMove error = errors.New("创建代码成功并移动文件成功")
 
 type SysAutoCode struct {
 	global.GVA_MODEL

--- a/server/router/enter.go
+++ b/server/router/enter.go
@@ -6,8 +6,8 @@ import (
 )
 
 type RouterGroup struct {
-	System   system.RouterGroup
-	Example  example.RouterGroup
+	System  system.RouterGroup
+	Example example.RouterGroup
 }
 
 var RouterGroupApp = new(RouterGroup)

--- a/server/service/system/sys_auto_code.go
+++ b/server/service/system/sys_auto_code.go
@@ -360,7 +360,7 @@ func (autoCodeService *AutoCodeService) CreateTemp(autoCode system.AutoCodeStruc
 		return err
 	}
 	if autoCode.AutoMoveFile {
-		return system.AutoMoveErr
+		return system.ErrAutoMove
 	}
 	return nil
 }

--- a/web/src/components/upload/common.vue
+++ b/web/src/components/upload/common.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
     <el-upload
-        :action="`${path}/fileUploadAndDownload/upload`"
-        :before-upload="checkFile"
-        :headers="{ 'x-token': userStore.token }"
-        :on-error="uploadError"
-        :on-success="uploadSuccess"
-        :show-file-list="false"
-        class="upload-btn"
+      :action="`${path}/fileUploadAndDownload/upload`"
+      :before-upload="checkFile"
+      :headers="{ 'x-token': userStore.token }"
+      :on-error="uploadError"
+      :on-success="uploadSuccess"
+      :show-file-list="false"
+      class="upload-btn"
     >
       <el-button size="small" type="primary">普通上传</el-button>
     </el-upload>

--- a/web/src/permission.js
+++ b/web/src/permission.js
@@ -2,7 +2,6 @@ import { useUserStore } from '@/pinia/modules/user'
 import { useRouterStore } from '@/pinia/modules/router'
 import getPageTitle from '@/utils/page'
 import router from '@/router'
-import { ElProgress } from 'element-plus'
 
 let asyncRouterFlag = 0
 

--- a/web/src/view/about/index.vue
+++ b/web/src/view/about/index.vue
@@ -98,7 +98,8 @@
           </div>
           <el-button
             class="load-more"
-            type="primary" link
+            type="primary"
+            link
             @click="loadMore"
           >Load more</el-button>
         </el-card>
@@ -116,7 +117,7 @@ export default {
 <script setup>
 import { ref } from 'vue'
 import { Commits, Members } from '@/api/github'
-import {formatTimeToStr} from "@/utils/date";
+import { formatTimeToStr } from '@/utils/date'
 const page = ref(0)
 
 const loadMore = () => {

--- a/web/src/view/dashboard/dashboardCharts/echartsLine.vue
+++ b/web/src/view/dashboard/dashboardCharts/echartsLine.vue
@@ -43,7 +43,7 @@ for (var i = 0; i < data.length; i++) {
 const chart = shallowRef(null)
 const echart = ref(null)
 const initChart = () => {
-  chart.value = echarts.init(echart.value, /*'macarons'*/)
+  chart.value = echarts.init(echart.value /* 'macarons' */)
   setOptions()
 }
 const setOptions = () => {

--- a/web/src/view/example/upload/upload.vue
+++ b/web/src/view/example/upload/upload.vue
@@ -82,7 +82,6 @@
 <script setup>
 import { getFileList, deleteFile, editFileName } from '@/api/fileUploadAndDownload'
 import { downloadImage } from '@/utils/downloadImg'
-import { useUserStore } from '@/pinia/modules/user'
 import CustomPic from '@/components/customPic/index.vue'
 import UploadImage from '@/components/upload/image.vue'
 import UploadCommon from '@/components/upload/common.vue'
@@ -93,7 +92,6 @@ import { ref } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 
 const path = ref(import.meta.env.VITE_BASE_API)
-const userStore = useUserStore()
 
 const imageUrl = ref('')
 const imageCommon = ref('')

--- a/web/src/view/layout/screenfull/index.vue
+++ b/web/src/view/layout/screenfull/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div @click="clickFull">
-    <div class="gvaIcon gvaIcon-fullscreen-expand" v-if="isShow"></div>
-    <div v-else class="gvaIcon gvaIcon-fullscreen-shrink"></div>
+    <div v-if="isShow" class="gvaIcon gvaIcon-fullscreen-expand" />
+    <div v-else class="gvaIcon gvaIcon-fullscreen-shrink" />
   </div>
 </template>
 

--- a/web/src/view/layout/search/search.vue
+++ b/web/src/view/layout/search/search.vue
@@ -23,13 +23,13 @@
       v-if="btnShow"
       class="user-box"
     >
-      <div class="gvaIcon gvaIcon-refresh" :class="[reload ? 'reloading' : '']" @click="handleReload"></div>
+      <div class="gvaIcon gvaIcon-refresh" :class="[reload ? 'reloading' : '']" @click="handleReload" />
     </div>
     <div
       v-if="btnShow"
       class="user-box"
     >
-      <div class="gvaIcon gvaIcon-search" @click="showSearch"></div>
+      <div class="gvaIcon gvaIcon-search" @click="showSearch" />
     </div>
     <div
       v-if="btnShow"
@@ -41,7 +41,7 @@
       v-if="btnShow"
       class="user-box"
     >
-      <div class="gvaIcon gvaIcon-customer-service" @click="toService"></div>
+      <div class="gvaIcon gvaIcon-customer-service" @click="toService" />
     </div>
   </div>
 </template>

--- a/web/src/view/systemTools/system/system.vue
+++ b/web/src/view/systemTools/system/system.vue
@@ -5,7 +5,7 @@
       <el-collapse v-model="activeNames">
         <el-collapse-item title="系统配置" name="1">
           <el-form-item label="环境值">
-<!--            <el-input v-model="config.system.env" />-->
+            <!-- <el-input v-model="config.system.env" />-->
             <el-select v-model="config.system.env" style="width:100%">
               <el-option value="public" />
               <el-option value="develop" />


### PR DESCRIPTION
去除server不必要的case break代码，
system.AutoMoveErr 重命名为 system.ErrAutoMove，更符合命名规范