### PR TITLE
feat:'左侧菜单item修改左内边距'

### DIFF
--- a/web/src/view/layout/aside/asideComponent/asyncSubmenu.vue
+++ b/web/src/view/layout/aside/asideComponent/asyncSubmenu.vue
@@ -90,6 +90,6 @@ watch(() => props.theme, () => {
   }
 
 .gva-subMenu {
-  padding-left: 6px;
+  padding-left: 4px;
 }
 </style>

--- a/web/src/view/layout/aside/asideComponent/asyncSubmenu.vue
+++ b/web/src/view/layout/aside/asideComponent/asyncSubmenu.vue
@@ -89,4 +89,7 @@ watch(() => props.theme, () => {
     }
   }
 
+.gva-subMenu {
+  padding-left: 6px;
+}
 </style>

--- a/web/src/view/layout/aside/asideComponent/menuItem.vue
+++ b/web/src/view/layout/aside/asideComponent/menuItem.vue
@@ -78,6 +78,7 @@ watch(() => props.theme, () => {
     display: flex;
     justify-content: flex-start;
     align-items: center;
+	padding-left: 6px;
 
 .gva-menu-item-title {
     flex:1;

--- a/web/src/view/layout/aside/asideComponent/menuItem.vue
+++ b/web/src/view/layout/aside/asideComponent/menuItem.vue
@@ -78,7 +78,7 @@ watch(() => props.theme, () => {
     display: flex;
     justify-content: flex-start;
     align-items: center;
-	padding-left: 6px;
+    padding-left: 4px;
 
 .gva-menu-item-title {
     flex:1;


### PR DESCRIPTION
左侧菜单item，图标和左侧边距太紧。增加item项的左内边距，让图标和边框之间有6px间距，看起来美观一点。
目录菜单也是同样的处理。