### PR TITLE
代码自动创建配置参数AutoCode.Root改为配置文件值优先

### DIFF
--- a/server/core/viper.go
+++ b/server/core/viper.go
@@ -69,6 +69,8 @@ func Viper(path ...string) *viper.Viper {
 	}
 
 	// root 适配性 根据root位置去找到对应迁移位置,保证root路径有效
-	global.GVA_CONFIG.AutoCode.Root, _ = filepath.Abs("..")
+	if global.GVA_CONFIG.AutoCode.Root == "" {
+		global.GVA_CONFIG.AutoCode.Root, _ = filepath.Abs("..")
+	}
 	return v
 }


### PR DESCRIPTION
代码自动创建功能中，代码根目录是以二进制文件目录优先(导致我定义了root结果还是失败看了半天发现被覆盖了)，感觉不太合理，正常工作中无论开发和运行bin目录跟源码目录都不一定在一起，建议采用配置值优先
如果想用bin的，配置文件不定义root即可不影响