### PR TITLE
@sakishum 去除 json tag 多余的双引号

### DIFF
--- a/server/model/system/response/sys_captcha.go
+++ b/server/model/system/response/sys_captcha.go
@@ -3,5 +3,5 @@ package response
 type SysCaptchaResponse struct {
 	CaptchaId     string `json:"captchaId"`
 	PicPath       string `json:"picPath"`
-	CaptchaLength int    `json:"captchaLength""`
+	CaptchaLength int    `json:"captchaLength"`
 }


### PR DESCRIPTION
去除结构体 SysCaptchaResponse 字段CaptchaLength 的 json tag 多余的双引号