### PR TITLE
closeLoading()的时候先判断接口是否开启了loading,解决showLoading()失效问题

### DIFF
--- a/web/src/utils/request.js
+++ b/web/src/utils/request.js
@@ -45,7 +45,9 @@ service.interceptors.request.use(
     return config
   },
   error => {
-    closeLoading()
+    if (!error.config.donNotShowLoading) {
+      closeLoading()
+    }
     ElMessage({
       showClose: true,
       message: error,
@@ -59,7 +61,9 @@ service.interceptors.request.use(
 service.interceptors.response.use(
   response => {
     const userStore = useUserStore()
-    closeLoading()
+    if (!response.config.donNotShowLoading) {
+      closeLoading()
+    }
     if (response.headers['new-token']) {
       userStore.setToken(response.headers['new-token'])
     }
@@ -83,7 +87,9 @@ service.interceptors.response.use(
     }
   },
   error => {
-    closeLoading()
+    if (!error.config.donNotShowLoading) {
+      closeLoading()
+    }
 
     if (!error.response) {
       ElMessageBox.confirm(`


### PR DESCRIPTION
## 结论:
如果有接口的donNotShowLoading设置为true的时候,没有判断这个值的情况下直接调用closeLoading,会导致acitveAxios一直累减,然后下个需要显示loading的接口,就无法显示loading了,因为acitveAxios的值仍然小于0


## 复现
1.增加三个接口
```
export const GetData = () => {
  return service({
    url: '/api/getdata',
    method: 'GET'
  })
}

export const NotShowOne = () => {
  return service({
    url: '/api/test1',
    method: 'GET',
    donNotShowLoading: true
  })
}

export const NotShowTwo = () => {
  return service({
    url: '/api/test1',
    method: 'GET',
    donNotShowLoading: true
  })
}
```
2.点击按钮依次调用上面的接口,第一次调用的时候GetData接口的loading显示正常.由于没有判断donNotShowLoading是否为true就直接closeLoading(),导致acitveAxios的值和接口调用次数不一致,就会导致第二次调用GetData接口的时候,loading无法显示