### PR TITLE
fix:service\system\sys_authority.go:修改没有正确处理err;取消多余if 判断

### DIFF
--- a/server/service/system/sys_authority.go
+++ b/server/service/system/sys_authority.go
@@ -125,14 +125,15 @@ func (authorityService *AuthorityService) DeleteAuthority(auth *system.SysAuthor
 			return
 		}
 		// err = db.Association("SysBaseMenus").Delete(&auth)
-	} else {
-		err = db.Error
-		if err != nil {
-			return
-		}
 	}
 	err = global.GVA_DB.Delete(&[]system.SysUserAuthority{}, "sys_authority_authority_id = ?", auth.AuthorityId).Error
+	if err != nil {
+		return
+	}
 	err = global.GVA_DB.Delete(&[]system.SysAuthorityBtn{}, "authority_id = ?", auth.AuthorityId).Error
+	if err != nil {
+		return
+	}
 	authorityId := strconv.Itoa(int(auth.AuthorityId))
 	CasbinServiceApp.ClearCasbin(0, authorityId)
 	return err
@@ -153,10 +154,8 @@ func (authorityService *AuthorityService) GetAuthorityInfoList(info request.Page
 	}
 	var authority []system.SysAuthority
 	err = db.Limit(limit).Offset(offset).Preload("DataAuthorityId").Where("parent_id = ?", "0").Find(&authority).Error
-	if len(authority) > 0 {
-		for k := range authority {
-			err = authorityService.findChildrenAuthority(&authority[k])
-		}
+	for k := range authority {
+		err = authorityService.findChildrenAuthority(&authority[k])
 	}
 	return authority, total, err
 }


### PR DESCRIPTION
DeleteAuthority方法修改没有正确处理err导致返回的err信息不正确
GetAuthorityInfoList方法取消多余的if判断,减少阅读疑惑