### PR TITLE
bugfix: 通过修改配置文件使得跨域白名单正常生效

### DIFF
--- a/server/config.yaml
+++ b/server/config.yaml
@@ -189,7 +189,7 @@ Timer:
 cors:
   mode: strict-whitelist # 放行模式: allow-all, 放行全部; whitelist, 白名单模式, 来自白名单内域名的请求添加 cors 头; strict-whitelist 严格白名单模式, 白名单外的请求一律拒绝
   whitelist:
-    - allow-origin: http://localhost:8081
+    - allow-origin: example1.com
       allow-headers: Content-Type,AccessToken,X-CSRF-Token, Authorization, Token,X-Token,X-User-Id
       allow-methods: POST, GET
       expose-headers: Content-Length, Access-Control-Allow-Origin, Access-Control-Allow-Headers, Content-Type

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -187,12 +187,13 @@ Timer:
 # 跨域配置
 # 需要配合 server/initialize/router.go#L32 使用
 cors:
-  mode: whitelist # 放行模式: allow-all, 放行全部; whitelist, 白名单模式, 来自白名单内域名的请求添加 cors 头; strict-whitelist 严格白名单模式, 白名单外的请求一律拒绝
+  mode: strict-whitelist # 放行模式: allow-all, 放行全部; whitelist, 白名单模式, 来自白名单内域名的请求添加 cors 头; strict-whitelist 严格白名单模式, 白名单外的请求一律拒绝
   whitelist:
-    - allow-origin: example1.com
-      allow-headers: content-type
-      allow-methods: GET, POST
+    - allow-origin: http://localhost:8081
+      allow-headers: Content-Type,AccessToken,X-CSRF-Token, Authorization, Token,X-Token,X-User-Id
+      allow-methods: POST, GET
       expose-headers: Content-Length, Access-Control-Allow-Origin, Access-Control-Allow-Headers, Content-Type
+
       allow-credentials: true # 布尔值
     - allow-origin: example2.com
       allow-headers: content-type

--- a/server/initialize/router.go
+++ b/server/initialize/router.go
@@ -31,7 +31,7 @@ func Routers() *gin.Engine {
 	// Router.Use(middleware.LoadTls())  // 如果需要使用https 请打开此中间件 然后前往 core/server.go 将启动模式 更变为 Router.RunTLS("端口","你的cre/pem文件","你的key文件")
 	// 跨域，如需跨域可以打开下面的注释
 	// Router.Use(middleware.Cors()) // 直接放行全部跨域请求
-	Router.Use(middleware.CorsByRules()) // 按照配置的规则放行跨域请求
+	// Router.Use(middleware.CorsByRules()) // 按照配置的规则放行跨域请求
 	//global.GVA_LOG.Info("use middleware cors")
 	Router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	global.GVA_LOG.Info("register swagger handler")

--- a/server/initialize/router.go
+++ b/server/initialize/router.go
@@ -31,7 +31,7 @@ func Routers() *gin.Engine {
 	// Router.Use(middleware.LoadTls())  // 如果需要使用https 请打开此中间件 然后前往 core/server.go 将启动模式 更变为 Router.RunTLS("端口","你的cre/pem文件","你的key文件")
 	// 跨域，如需跨域可以打开下面的注释
 	// Router.Use(middleware.Cors()) // 直接放行全部跨域请求
-	//Router.Use(middleware.CorsByRules()) // 按照配置的规则放行跨域请求
+	Router.Use(middleware.CorsByRules()) // 按照配置的规则放行跨域请求
 	//global.GVA_LOG.Info("use middleware cors")
 	Router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	global.GVA_LOG.Info("register swagger handler")

--- a/server/middleware/cors.go
+++ b/server/middleware/cors.go
@@ -52,7 +52,7 @@ func CorsByRules() gin.HandlerFunc {
 			c.AbortWithStatus(http.StatusForbidden)
 		} else {
 			// 非严格白名单模式，无论是否通过检查均放行所有 OPTIONS 方法
-			if c.Request.Method == "OPTIONS" {
+			if c.Request.Method == http.MethodOptions {
 				c.AbortWithStatus(http.StatusNoContent)
 			}
 		}


### PR DESCRIPTION
解决这个[issue](https://github.com/flipped-aurora/gin-vue-admin/issues/1293)

这个issue产生的原因是可能是（不确定用户实际怎么写的） allow-headers是配置少了一些字段。

我这次加上下面这些，白名单就能正常工作了。已经测试。

```
allow-headers: Content-Type,AccessToken,X-CSRF-Token, Authorization, Token,X-Token,X-User-Id
```