### PR TITLE
fix(sec): upgrade nhooyr.io/websocket to 1.8.7

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -41,7 +41,7 @@ require (
 	gorm.io/driver/postgres v1.3.4
 	gorm.io/driver/sqlserver v1.3.2
 	gorm.io/gorm v1.23.4
-	nhooyr.io/websocket v1.8.6
+	nhooyr.io/websocket v1.8.7
 )
 
 require (

--- a/server/go.sum
+++ b/server/go.sum
@@ -968,4 +968,6 @@ modernc.org/token v1.0.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
 modernc.org/z v1.3.2/go.mod h1:PEU2oK2OEA1CfzDTd+8E908qEXhC9s0MfyKp5LZsd+k=
 nhooyr.io/websocket v1.8.6 h1:s+C3xAMLwGmlI31Nyn/eAehUlZPwfYZu2JXM621Q5/k=
 nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
+nhooyr.io/websocket v1.8.7 h1:usjR2uOr/zjjkVMy0lW+PPohFok7PCow5sDjLgX4P4g=
+nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in nhooyr.io/websocket v1.8.6
- [MPS-2022-13514](https://www.oscs1024.com/hd/MPS-2022-13514)


### What did I do？
Upgrade nhooyr.io/websocket from v1.8.6 to 1.8.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS