### PR TITLE
新增权限初始化时适配数据库的出错日志

### DIFF
--- a/server/service/system/sys_casbin.go
+++ b/server/service/system/sys_casbin.go
@@ -104,7 +104,11 @@ var (
 
 func (casbinService *CasbinService) Casbin() *casbin.CachedEnforcer {
 	once.Do(func() {
-		a, _ := gormadapter.NewAdapterByDB(global.GVA_DB)
+		a, err := gormadapter.NewAdapterByDB(global.GVA_DB)
+		if err != nil {
+			zap.L().Error("适配数据库失败!", zap.Error(err))
+			return
+		}
 		text := `
 		[request_definition]
 		r = sub, obj, act


### PR DESCRIPTION
项目在一个新的环境初始化数据库时，如果数据库的引擎不是InnoDB，则会在casbin初始化时进行报错，无法获取到数据库数据，故将在casbin初始化时的err进行了判断，出错时抛出错误。