### PR TITLE
fixbug: 修复代码生成器无法自动导入 time 包问题

### DIFF
--- a/server/service/system/sys_auto_code.go
+++ b/server/service/system/sys_auto_code.go
@@ -134,15 +134,12 @@ func (autoCodeService *AutoCodeService) PreviewTemp(autoCode system.AutoCodeStru
 	for i := range autoCode.Fields {
 		if autoCode.Fields[i].FieldType == "time.Time" {
 			autoCode.HasTimer = true
-			break
 		}
 		if autoCode.Fields[i].Require {
 			autoCode.NeedValid = true
-			break
 		}
 		if autoCode.Fields[i].Sort {
 			autoCode.NeedSort = true
-			break
 		}
 	}
 	dataList, _, needMkdir, err := autoCodeService.getNeedList(&autoCode)
@@ -227,15 +224,12 @@ func (autoCodeService *AutoCodeService) CreateTemp(autoCode system.AutoCodeStruc
 	for i := range autoCode.Fields {
 		if autoCode.Fields[i].FieldType == "time.Time" {
 			autoCode.HasTimer = true
-			break
 		}
 		if autoCode.Fields[i].Require {
 			autoCode.NeedValid = true
-			break
 		}
 		if autoCode.Fields[i].Sort {
 			autoCode.NeedSort = true
-			break
 		}
 	}
 	// 增加判断: 重复创建struct


### PR DESCRIPTION
原本 for 循环下 if 判断只有 HasTimer 判断，加了 break 可以提前跳出循环，但另外新增了 NeedValid 和 NeedSort 判断后，直接跳出循环会导致无法正常设置 HasTimer ，NeedValid 和 NeedSort