### PR TITLE
fix: api layer can not get autofill primary key in automatically gene…

### DIFF
--- a/server/resource/autocode_template/server/api.go.tpl
+++ b/server/resource/autocode_template/server/api.go.tpl
@@ -54,7 +54,7 @@ func ({{.Abbreviation}}Api *{{.StructName}}Api) Create{{.StructName}}(c *gin.Con
     		return
     	}
     {{- end }}
-	if err := {{.Abbreviation}}Service.Create{{.StructName}}({{.Abbreviation}}); err != nil {
+	if err := {{.Abbreviation}}Service.Create{{.StructName}}(&{{.Abbreviation}}); err != nil {
         global.GVA_LOG.Error("创建失败!", zap.Error(err))
 		response.FailWithMessage("创建失败", c)
 	} else {

--- a/server/resource/autocode_template/server/service.go.tpl
+++ b/server/resource/autocode_template/server/service.go.tpl
@@ -22,8 +22,8 @@ type {{.StructName}}Service struct {
 
 // Create{{.StructName}} 创建{{.StructName}}记录
 // Author [piexlmax](https://github.com/piexlmax)
-func ({{.Abbreviation}}Service *{{.StructName}}Service) Create{{.StructName}}({{.Abbreviation}} {{.Package}}.{{.StructName}}) (err error) {
-	err = {{$db}}.Create(&{{.Abbreviation}}).Error
+func ({{.Abbreviation}}Service *{{.StructName}}Service) Create{{.StructName}}({{.Abbreviation}} *{{.Package}}.{{.StructName}}) (err error) {
+	err = {{$db}}.Create({{.Abbreviation}}).Error
 	return err
 }
 


### PR DESCRIPTION
在自动生成的代码中，只有service层的方法里面的局部变量调用时才能拿到主键回填的值，有的时候api层需要调用创建方法后使用主键回填的值再进行下一步操作，这个时候如果没有注意修改service层的创建方法的话，api层调用service层的创建方法传入的对象的值一直为0