### PR TITLE
fix: 修复字典按ID排序而非sort排序问题

### DIFF
--- a/server/service/system/sys_dictionary.go
+++ b/server/service/system/sys_dictionary.go
@@ -87,7 +87,9 @@ func (dictionaryService *DictionaryService) GetSysDictionary(Type string, Id uin
 	} else {
 		flag = *status
 	}
-	err = global.GVA_DB.Where("(type = ? OR id = ?) and status = ?", Type, Id, flag).Preload("SysDictionaryDetails", "status = ?", true).First(&sysDictionary).Error
+	err = global.GVA_DB.Where("(type = ? OR id = ?) and status = ?", Type, Id, flag).Preload("SysDictionaryDetails", func(db *gorm.DB) *gorm.DB {
+		return db.Where("status = ?", true).Order("sort")
+	}).First(&sysDictionary).Error
 	return
 }
 


### PR DESCRIPTION
直接使用Preload加载的字典值是按ID排序的，在前端展示时并非希望的sort排序