### PR TITLE
避免配置文件的注释中引用行号变更带来的歧义

### DIFF
--- a/server/config.docker.yaml
+++ b/server/config.docker.yaml
@@ -187,7 +187,7 @@ Timer:
       interval: 168h
 
 # 跨域配置
-# 需要配合 server/initialize/router.go#L32 使用
+# 需要配合 server/initialize/router.go -> `Router.Use(middleware.CorsByRules())` 使用
 cors:
   mode: whitelist # 放行模式: allow-all, 放行全部; whitelist, 白名单模式, 来自白名单内域名的请求添加 cors 头; strict-whitelist 严格白名单模式, 白名单外的请求一律拒绝
   whitelist:

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -209,7 +209,7 @@ Timer:
       interval: 168h
 
 # 跨域配置
-# 需要配合 server/initialize/router.go#L32 使用
+# 需要配合 server/initialize/router.go -> `Router.Use(middleware.CorsByRules())` 使用
 cors:
   mode: strict-whitelist # 放行模式: allow-all, 放行全部; whitelist, 白名单模式, 来自白名单内域名的请求添加 cors 头; strict-whitelist 严格白名单模式, 白名单外的请求一律拒绝
   whitelist:


### PR DESCRIPTION
配置文件中引用的 server/initialize/router.go#L32 由于文件修改，已经不是跨域配置相关的代码，产生了歧义