### PR TITLE
fix: 修复并发请求API情况下的读写冲突问题

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/aliyun/aliyun-oss-go-sdk v2.1.6+incompatible
 	github.com/aws/aws-sdk-go v1.42.27
-	github.com/casbin/casbin/v2 v2.51.0
+	github.com/casbin/casbin/v2 v2.68.0
 	github.com/casbin/gorm-adapter/v3 v3.7.3
 	github.com/flipped-aurora/ws v1.0.2
 	github.com/fsnotify/fsnotify v1.4.9

--- a/server/go.sum
+++ b/server/go.sum
@@ -50,6 +50,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/casbin/casbin/v2 v2.37.4/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
 github.com/casbin/casbin/v2 v2.51.0 h1:BC41imD9Z2coIJpELapy2h5kMT+lB4vFDTYpMhTsU4A=
 github.com/casbin/casbin/v2 v2.51.0/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
+github.com/casbin/casbin/v2 v2.68.0 h1:7L4kwNJJw/pzdSEhl4SkeHz+1JzYn8guO+Q422sxzLM=
+github.com/casbin/casbin/v2 v2.68.0/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
 github.com/casbin/gorm-adapter/v3 v3.7.3 h1:tp3EL3vS31dF+GX0n3QwUytQlrFOPXtOKKZ7SZtLOA8=
 github.com/casbin/gorm-adapter/v3 v3.7.3/go.mod h1:7mwHmC2phiw6N4gDWlzi+c4DUX7zaVmQC/hINsRgBDg=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/server/service/system/sys_casbin.go
+++ b/server/service/system/sys_casbin.go
@@ -2,6 +2,9 @@ package system
 
 import (
 	"errors"
+	"strconv"
+	"sync"
+
 	"github.com/casbin/casbin/v2"
 	"github.com/casbin/casbin/v2/model"
 	gormadapter "github.com/casbin/gorm-adapter/v3"
@@ -9,8 +12,6 @@ import (
 	"github.com/flipped-aurora/gin-vue-admin/server/model/system/request"
 	_ "github.com/go-sql-driver/mysql"
 	"go.uber.org/zap"
-	"strconv"
-	"sync"
 )
 
 //@author: [piexlmax](https://github.com/piexlmax)
@@ -98,11 +99,11 @@ func (casbinService *CasbinService) ClearCasbin(v int, p ...string) bool {
 //@return: *casbin.Enforcer
 
 var (
-	cachedEnforcer *casbin.CachedEnforcer
-	once           sync.Once
+	syncedCachedEnforcer *casbin.SyncedCachedEnforcer
+	once                 sync.Once
 )
 
-func (casbinService *CasbinService) Casbin() *casbin.CachedEnforcer {
+func (casbinService *CasbinService) Casbin() *casbin.SyncedCachedEnforcer {
 	once.Do(func() {
 		a, err := gormadapter.NewAdapterByDB(global.GVA_DB)
 		if err != nil {
@@ -130,9 +131,9 @@ func (casbinService *CasbinService) Casbin() *casbin.CachedEnforcer {
 			zap.L().Error("字符串加载模型失败!", zap.Error(err))
 			return
 		}
-		cachedEnforcer, _ = casbin.NewCachedEnforcer(m, a)
-		cachedEnforcer.SetExpireTime(60 * 60)
-		_ = cachedEnforcer.LoadPolicy()
+		syncedCachedEnforcer, _ = casbin.NewSyncedCachedEnforcer(m, a)
+		syncedCachedEnforcer.SetExpireTime(60 * 60)
+		_ = syncedCachedEnforcer.LoadPolicy()
 	})
-	return cachedEnforcer
+	return syncedCachedEnforcer
 }


### PR DESCRIPTION
CachedEnforcer不支持多并发场景，当API并发请求时服务会报出：fatal error: concurrent map writes。
解决方法：使用SyncedCachedEnforcer替换CachedEnforcer。
casbin版本: v2.68.0
由于v2.66.0有bug，重新提交