### PR TITLE
数据库打开失败直接panic,方便查找错误

### DIFF
--- a/server/initialize/gorm_mysql.go
+++ b/server/initialize/gorm_mysql.go
@@ -23,7 +23,7 @@ func GormMysql() *gorm.DB {
 
 	}
 	if db, err := gorm.Open(mysql.New(mysqlConfig), internal.Gorm.Config(m.Prefix, m.Singular)); err != nil {
-		return nil
+		panic(err)
 	} else {
 		db.InstanceSet("gorm:table_options", "ENGINE="+m.Engine)
 		sqlDB, _ := db.DB()


### PR DESCRIPTION
这里恐慌比较好,返回nil项目会启动,不利于错误查找