### PR TITLE
fix: macos和linux下代码定位命令不对 #1495

### DIFF
--- a/web/vitePlugin/codeServer/index.js
+++ b/web/vitePlugin/codeServer/index.js
@@ -31,7 +31,7 @@ export default function GvaPositionServer() {
                 )
               } else {
                 child_process.exec(
-                  `webstorm64  --line ${linePath} ${filePath}`
+                  `webstorm --line ${linePath} ${filePath}`
                 )
               }
             } else {


### PR DESCRIPTION
#1495 