### PR TITLE
feat: update ci add  CGO_ENABLED=0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Build-go
         run: |
-          cd server/ && go mod tidy && go build && mkdir ../web/ser && mv server ../web/ser/ && cd ../web/ser/ && ls -s 
+          cd server/ && go mod tidy && CGO_ENABLED=0 go build && mkdir ../web/ser && mv server ../web/ser/ && cd ../web/ser/ && ls -s 
       - name: restart
         env:
           KEY: ${{ secrets.KEY }}
@@ -220,7 +220,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Build-go
         run: |
-          cd server/ && go mod tidy && go build && mkdir ../web/ser && mv server ../web/ser/ && cd ../web/ser/ && ls -s 
+          cd server/ && go mod tidy && CGO_ENABLED=0 go build && mkdir ../web/ser && mv server ../web/ser/ && cd ../web/ser/ && ls -s 
       - name: restart
         env:
           KEY: ${{ secrets.KEY }}


### PR DESCRIPTION
修复demo环境构建，
![image](https://github.com/flipped-aurora/gin-vue-admin/assets/64051240/fa9db6a0-46d6-4693-917a-bc2c7ffc8ea2)

在ubuntu（action）打包的程序，在centos运行会有这个报错。实际解决思路是添加参数（CGO_ENABLED=0），或者让程序在centos环境打包，可以完美兼容centos和ubuntu，因为centos的版本较低，ubuntu做了兼容。