### PR TITLE
feat:'修改模板，自动创建不分页获取列表接口，并增加到前端api文件，及将api url增加到数据库'

### DIFF
--- a/server/model/common/response/common.go
+++ b/server/model/common/response/common.go
@@ -6,3 +6,7 @@ type PageResult struct {
 	Page     int         `json:"page"`
 	PageSize int         `json:"pageSize"`
 }
+
+type ResultAll struct {
+	List interface{} `json:"list"`
+}

--- a/server/resource/autocode_template/server/api.go.tpl
+++ b/server/resource/autocode_template/server/api.go.tpl
@@ -208,3 +208,22 @@ func ({{.Abbreviation}}Api *{{.StructName}}Api) Get{{.StructName}}List(c *gin.Co
         }, "获取成功", c)
     }
 }
+
+// Get{{.StructName}}ListAll 不分页获取{{.StructName}}列表
+// @Tags {{.StructName}}
+// @Summary 不分页获取{{.StructName}}列表
+// @Security ApiKeyAuth
+// @accept application/json
+// @Produce application/json
+// @Success 200 {string} string "{"success":true,"data":{},"msg":"获取成功"}"
+// @Router /{{.Abbreviation}}/get{{.StructName}}ListAll [get]
+func ({{.Abbreviation}}Api *{{.StructName}}Api) Get{{.StructName}}ListAll(c *gin.Context) {
+	if list, err := {{.Abbreviation}}Service.Get{{.StructName}}InfoListAll(); err != nil {
+	    global.GVA_LOG.Error("获取失败!", zap.Error(err))
+        response.FailWithMessage("获取失败", c)
+    } else {
+        response.OkWithDetailed(response.ResultAll{
+            List:     list,
+        }, "获取成功", c)
+    }
+}

--- a/server/resource/autocode_template/server/router.go.tpl
+++ b/server/resource/autocode_template/server/router.go.tpl
@@ -22,6 +22,7 @@ func (s *{{.StructName}}Router) Init{{.StructName}}Router(Router *gin.RouterGrou
 	}
 	{
 		{{.Abbreviation}}RouterWithoutRecord.GET("find{{.StructName}}", {{.Abbreviation}}Api.Find{{.StructName}})        // 根据ID获取{{.StructName}}
-		{{.Abbreviation}}RouterWithoutRecord.GET("get{{.StructName}}List", {{.Abbreviation}}Api.Get{{.StructName}}List)  // 获取{{.StructName}}列表
+		{{.Abbreviation}}RouterWithoutRecord.GET("get{{.StructName}}List", {{.Abbreviation}}Api.Get{{.StructName}}List)  // 分页获取{{.StructName}}列表
+		{{.Abbreviation}}RouterWithoutRecord.GET("get{{.StructName}}ListAll", {{.Abbreviation}}Api.Get{{.StructName}}ListAll)  // 不分页获取{{.StructName}}列表
 	}
 }

--- a/server/resource/autocode_template/server/service.go.tpl
+++ b/server/resource/autocode_template/server/service.go.tpl
@@ -132,3 +132,13 @@ func ({{.Abbreviation}}Service *{{.StructName}}Service)Get{{.StructName}}InfoLis
 	err = db.Limit(limit).Offset(offset).Find(&{{.Abbreviation}}s).Error
 	return  {{.Abbreviation}}s, total, err
 }
+
+// Get{{.StructName}}InfoListAll 不分页获取{{.StructName}}记录
+func ({{.Abbreviation}}Service *{{.StructName}}Service)Get{{.StructName}}InfoListAll() (list []{{.Package}}.{{.StructName}}, err error) {
+	// 创建db
+	db := {{$db}}.Model(&{{.Package}}.{{.StructName}}{})
+    var {{.Abbreviation}}s []{{.Package}}.{{.StructName}}
+
+	err = db.Find(&{{.Abbreviation}}s).Error
+	return  {{.Abbreviation}}s, err
+}

--- a/server/resource/autocode_template/web/api.js.tpl
+++ b/server/resource/autocode_template/web/api.js.tpl
@@ -95,3 +95,17 @@ export const get{{.StructName}}List = (params) => {
     params
   })
 }
+
+// @Tags {{.StructName}}
+// @Summary 不分页获取{{.StructName}}列表
+// @Security ApiKeyAuth
+// @accept application/json
+// @Produce application/json
+// @Success 200 {string} string "{"success":true,"data":{},"msg":"获取成功"}"
+// @Router /{{.Abbreviation}}/get{{.StructName}}ListAll [get]
+export const get{{.StructName}}ListAll = () => {
+  return service({
+    url: '/{{.Abbreviation}}/get{{.StructName}}ListAll',
+    method: 'get'
+  })
+}

--- a/server/service/system/sys_auto_code.go
+++ b/server/service/system/sys_auto_code.go
@@ -505,7 +505,13 @@ func (autoCodeService *AutoCodeService) AutoCreateApi(a *system.AutoCodeStruct) 
 		},
 		{
 			Path:        "/" + a.Abbreviation + "/" + "get" + a.StructName + "List",
-			Description: "获取" + a.Description + "列表",
+			Description: "分页获取" + a.Description + "列表",
+			ApiGroup:    a.Description,
+			Method:      "GET",
+		},
+		{
+			Path:        "/" + a.Abbreviation + "/" + "get" + a.StructName + "ListAll",
+			Description: "不分页获取" + a.Description + "列表",
 			ApiGroup:    a.Description,
 			Method:      "GET",
 		},


### PR DESCRIPTION
目前只有分页获取列表，开发中经常需要不分页获取全部数据
所以增加了这个模板
增加路由，增加api，增加service，增加返回，写入前端api.js，自动将api url创建到数据库