### PR TITLE
分页列表接口，兼容不分页获取全部数据

### DIFF
--- a/server/resource/autocode_template/server/service.go.tpl
+++ b/server/resource/autocode_template/server/service.go.tpl
@@ -129,6 +129,10 @@ func ({{.Abbreviation}}Service *{{.StructName}}Service)Get{{.StructName}}InfoLis
        }
     {{- end}}
 
-	err = db.Limit(limit).Offset(offset).Find(&{{.Abbreviation}}s).Error
+	if limit == 0 {
+       err = db.Find(&{{.Abbreviation}}s).Error
+    } else {
+       err = db.Limit(limit).Offset(offset).Find(&{{.Abbreviation}}s).Error
+    }
 	return  {{.Abbreviation}}s, total, err
 }

--- a/server/resource/autocode_template/server/service.go.tpl
+++ b/server/resource/autocode_template/server/service.go.tpl
@@ -129,10 +129,10 @@ func ({{.Abbreviation}}Service *{{.StructName}}Service)Get{{.StructName}}InfoLis
        }
     {{- end}}
 
-	if limit == 0 {
-       err = db.Find(&{{.Abbreviation}}s).Error
-    } else {
-       err = db.Limit(limit).Offset(offset).Find(&{{.Abbreviation}}s).Error
+	if limit != 0 {
+       db = db.Limit(limit).Offset(offset)
     }
+	
+	err = db.Find(&{{.Abbreviation}}s).Error
 	return  {{.Abbreviation}}s, total, err
 }


### PR DESCRIPTION
分页获取数据接口，增加判断pagesize，如果不传分页参数或pagesize为0，不分页返回所有数据。