### PR TITLE
fix: 修复菜单折叠后再次展开右侧出现遮罩的问题

### DIFF
--- a/web/src/view/layout/index.vue
+++ b/web/src/view/layout/index.vue
@@ -1,7 +1,7 @@
 <template>
   <el-container class="layout-cont">
     <el-container :class="[isSider?'openside':'hideside',isMobile ? 'mobile': '']">
-      <el-row :class="[isShadowBg?'bg-black opacity-30 w-full h-full absolute top-0 left-0 z-[1001]':'']" @click="changeShadow()" />
+      <el-row :class="[isShadowBg && isMobile?'bg-black opacity-30 w-full h-full absolute top-0 left-0 z-[1001]':'']" @click="changeShadow()" />
       <el-aside class="main-cont gva-aside" :style="{width:asideWidth()}">
         <div class="min-h-[60px] text-center transition-all duration-300 flex items-center justify-center gap-2" :style="{background: backgroundColor}">
           <img alt class="w-9 h-9 p-1 bg-white rounded-full" :src="$GIN_VUE_ADMIN.appLogo">


### PR DESCRIPTION
修改为tailwindcss后，添加遮罩时没有判断是否为手机端