### PR TITLE
修复popover提醒显示逻辑，在未选中任何行时禁止显示

### DIFF
--- a/server/resource/autocode_template/web/table.vue.tpl
+++ b/server/resource/autocode_template/web/table.vue.tpl
@@ -84,7 +84,7 @@
     <div class="gva-table-box">
         <div class="gva-btn-list">
             <el-button type="primary" icon="plus" @click="openDialog">新增</el-button>
-            <el-popover v-model:visible="deleteVisible" placement="top" width="160">
+            <el-popover v-model:visible="deleteVisible" :disabled="!multipleSelection.length" placement="top" width="160">
             <p>确定要删除吗？</p>
             <div style="text-align: right; margin-top: 8px;">
                 <el-button type="primary" link @click="deleteVisible = false">取消</el-button>


### PR DESCRIPTION
列表上方的批量删除popover提醒，只有选中内容时，才可以悬浮显示提醒，否则不显示popover。