### PR TITLE
修改批量删除的popover提示展示逻辑，调整table列顺序及名称

### DIFF
--- a/server/resource/autocode_template/web/table.vue.tpl
+++ b/server/resource/autocode_template/web/table.vue.tpl
@@ -84,7 +84,7 @@
     <div class="gva-table-box">
         <div class="gva-btn-list">
             <el-button type="primary" icon="plus" @click="openDialog">新增</el-button>
-            <el-popover v-model:visible="deleteVisible" placement="top" width="160">
+            <el-popover v-model:visible="deleteVisible" :disabled="!multipleSelection.length" placement="top" width="160">
             <p>确定要删除吗？</p>
             <div style="text-align: right; margin-top: 8px;">
                 <el-button type="primary" link @click="deleteVisible = false">取消</el-button>

--- a/server/resource/autocode_template/web/table.vue.tpl
+++ b/server/resource/autocode_template/web/table.vue.tpl
@@ -107,9 +107,6 @@
         {{- end}}
         >
         <el-table-column type="selection" width="55" />
-        <el-table-column align="left" label="日期" width="180">
-            <template #default="scope">{{ "{{ formatDate(scope.row.CreatedAt) }}" }}</template>
-        </el-table-column>
         {{- range .Fields}}
         {{- if .DictType}}
         <el-table-column {{- if .Sort}} sortable{{- end}} align="left" label="{{.FieldDesc}}" prop="{{.FieldJson}}" width="120">
@@ -157,13 +154,16 @@
         <el-table-column {{- if .Sort}} sortable{{- end}} align="left" label="{{.FieldDesc}}" prop="{{.FieldJson}}" width="120" />
         {{- end }}
         {{- end }}
+        <el-table-column align="left" label="日期" width="180">
+            <template #default="scope">{{ "{{ formatDate(scope.row.CreatedAt) }}" }}</template>
+        </el-table-column>
         <el-table-column align="left" label="操作">
             <template #default="scope">
             <el-button type="primary" link class="table-button" @click="getDetails(scope.row)">
                 <el-icon style="margin-right: 5px"><InfoFilled /></el-icon>
-                查看详情
+                查看
             </el-button>
-            <el-button type="primary" link icon="edit" class="table-button" @click="update{{.StructName}}Func(scope.row)">变更</el-button>
+            <el-button type="primary" link icon="edit" class="table-button" @click="update{{.StructName}}Func(scope.row)">编辑</el-button>
             <el-button type="primary" link icon="delete" @click="deleteRow(scope.row)">删除</el-button>
             </template>
         </el-table-column>


### PR DESCRIPTION
表格上方的批量删除悬浮提醒，修复为只有选中有内容时，悬浮才会显示提醒。未选中内容，悬浮不会显示popover提示。
调整table列顺序及名称，使得更适合一般项目使用，而无需每次都修改。