### PR TITLE
批量删除按钮，未选中内容时，悬浮不应该显示对话框

### DIFF
--- a/server/resource/autocode_template/web/table.vue.tpl
+++ b/server/resource/autocode_template/web/table.vue.tpl
@@ -84,7 +84,7 @@
     <div class="gva-table-box">
         <div class="gva-btn-list">
             <el-button type="primary" icon="plus" @click="openDialog">新增</el-button>
-            <el-popover v-model:visible="deleteVisible" placement="top" width="160">
+            <el-popover v-model:visible="deleteVisible" :disabled="!multipleSelection.length" placement="top" width="160">
             <p>确定要删除吗？</p>
             <div style="text-align: right; margin-top: 8px;">
                 <el-button type="primary" link @click="deleteVisible = false">取消</el-button>


### PR DESCRIPTION
table的批量删除按钮，未选中内容时候，悬浮提醒不应该显示。增加以下代码
:disabled="!multipleSelection.length"