### PR TITLE
验证码bug修复

### DIFF
--- a/server/api/v1/system/sys_user.go
+++ b/server/api/v1/system/sys_user.go
@@ -49,7 +49,7 @@ func (b *BaseApi) Login(c *gin.Context) {
 
 	var oc bool = openCaptcha == 0 || openCaptcha < interfaceToInt(v)
 
-	if !oc || store.Verify(l.CaptchaId, l.Captcha, true) {
+	if !oc || (l.CaptchaId != "" && l.Captcha != "" && store.Verify(l.CaptchaId, l.Captcha, true)) {
 		u := &system.SysUser{Username: l.Username, Password: l.Password}
 		user, err := userService.Login(u)
 		if err != nil {


### PR DESCRIPTION
验证码bug修复
验证码库[github.com/mojocn/base64Captcha](https://pkg.go.dev/github.com/mojocn/base64Captcha@v1.3.5)的设计问题，store.Verify()传入id不存在且answer为空，就会返回true，虽然很炸裂，但是他确实存在