### PR TITLE
update: zap 日志切割优化

### DIFF
--- a/server/core/internal/cutter.go
+++ b/server/core/internal/cutter.go
@@ -1,0 +1,97 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Cutter struct {
+	level    string        // 日志级别(debug, info, warn, error, dpanic, panic, fatal)
+	format   string        // 时间格式(2006-01-02)
+	Director string        // 日志文件夹
+	file     *os.File      // 文件句柄
+	mutex    *sync.RWMutex // 读写锁
+}
+
+type CutterOption func(*Cutter)
+
+// WithCutterFormat 设置时间格式
+func WithCutterFormat(format string) CutterOption {
+	return func(c *Cutter) {
+		c.format = format
+	}
+}
+
+func NewCutter(director string, level string, options ...CutterOption) *Cutter {
+	rotate := &Cutter{
+		level:    level,
+		Director: director,
+		mutex:    new(sync.RWMutex),
+	}
+	for i := 0; i < len(options); i++ {
+		options[i](rotate)
+	}
+	return rotate
+}
+
+// Write satisfies the io.Writer interface. It writes to the
+// appropriate file handle that is currently being used.
+// If we have reached rotation time, the target file gets
+// automatically rotated, and also purged if necessary.
+func (c *Cutter) Write(bytes []byte) (n int, err error) {
+	c.mutex.Lock()
+	defer func() {
+		if c.file != nil {
+			_ = c.file.Close()
+			c.file = nil
+		}
+		c.mutex.Unlock()
+	}()
+	var business string
+	if strings.Contains(string(bytes), "business") {
+		var compile *regexp.Regexp
+		compile, err = regexp.Compile(`{"business": "([^,]+)"}`)
+		if err != nil {
+			return 0, err
+		}
+		if compile.Match(bytes) {
+			finds := compile.FindSubmatch(bytes)
+			business = string(finds[len(finds)-1])
+			bytes = compile.ReplaceAll(bytes, []byte(""))
+		}
+		compile, err = regexp.Compile(`"business": "([^,]+)"`)
+		if err != nil {
+			return 0, err
+		}
+		if compile.Match(bytes) {
+			finds := compile.FindSubmatch(bytes)
+			business = string(finds[len(finds)-1])
+			bytes = compile.ReplaceAll(bytes, []byte(""))
+		}
+	}
+	format := time.Now().Format(c.format)
+	formats := make([]string, 0, 4)
+	formats = append(formats, c.Director)
+	if format != "" {
+		formats = append(formats, format)
+	}
+	if business != "" {
+		formats = append(formats, business)
+	}
+	formats = append(formats, c.level+".log")
+	filename := filepath.Join(formats...)
+	dirname := filepath.Dir(filename)
+	err = os.MkdirAll(dirname, 0755)
+	if err != nil {
+		return 0, err
+	}
+	c.file, err = os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return 0, err
+	}
+	return c.file.Write(bytes)
+}

--- a/server/core/internal/file_rotatelogs.go
+++ b/server/core/internal/file_rotatelogs.go
@@ -2,11 +2,8 @@ package internal
 
 import (
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
-	rotatelogs "github.com/lestrrat-go/file-rotatelogs"
 	"go.uber.org/zap/zapcore"
 	"os"
-	"path"
-	"time"
 )
 
 var FileRotatelogs = new(fileRotatelogs)
@@ -15,15 +12,10 @@ type fileRotatelogs struct{}
 
 // GetWriteSyncer 获取 zapcore.WriteSyncer
 // Author [SliverHorn](https://github.com/SliverHorn)
-func (r *fileRotatelogs) GetWriteSyncer(level string) (zapcore.WriteSyncer, error) {
-	fileWriter, err := rotatelogs.New(
-		path.Join(global.GVA_CONFIG.Zap.Director, "%Y-%m-%d", level+".log"),
-		rotatelogs.WithClock(rotatelogs.Local),
-		rotatelogs.WithMaxAge(time.Duration(global.GVA_CONFIG.Zap.MaxAge)*24*time.Hour), // 日志留存时间
-		rotatelogs.WithRotationTime(time.Hour*24),
-	)
+func (r *fileRotatelogs) GetWriteSyncer(level string) zapcore.WriteSyncer {
+	fileWriter := NewCutter(global.GVA_CONFIG.Zap.Director, level, WithCutterFormat("2006-01-02"))
 	if global.GVA_CONFIG.Zap.LogInConsole {
-		return zapcore.NewMultiWriteSyncer(zapcore.AddSync(os.Stdout), zapcore.AddSync(fileWriter)), err
+		return zapcore.NewMultiWriteSyncer(zapcore.AddSync(os.Stdout), zapcore.AddSync(fileWriter))
 	}
-	return zapcore.AddSync(fileWriter), err
+	return zapcore.AddSync(fileWriter)
 }

--- a/server/core/internal/zap.go
+++ b/server/core/internal/zap.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"fmt"
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -42,12 +41,7 @@ func (z *_zap) GetEncoderConfig() zapcore.EncoderConfig {
 // GetEncoderCore 获取Encoder的 zapcore.Core
 // Author [SliverHorn](https://github.com/SliverHorn)
 func (z *_zap) GetEncoderCore(l zapcore.Level, level zap.LevelEnablerFunc) zapcore.Core {
-	writer, err := FileRotatelogs.GetWriteSyncer(l.String()) // 使用file-rotatelogs进行日志分割
-	if err != nil {
-		fmt.Printf("Get Write Syncer Failed err:%v", err.Error())
-		return nil
-	}
-
+	writer := FileRotatelogs.GetWriteSyncer(l.String()) // 日志分割
 	return zapcore.NewCore(z.GetEncoder(), writer, level)
 }
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/gookit/color v1.5.4
 	github.com/huaweicloud/huaweicloud-sdk-go-obs v3.21.8+incompatible
 	github.com/jordan-wright/email v0.0.0-20200824153738-3f5bafa1cd84
-	github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible
 	github.com/mojocn/base64Captcha v1.3.5
 	github.com/otiai10/copy v1.7.0
 	github.com/pkg/errors v0.9.1
@@ -80,13 +79,11 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
-	github.com/lestrrat-go/strftime v1.0.6 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -268,8 +268,6 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
-github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/jordan-wright/email v0.0.0-20200824153738-3f5bafa1cd84 h1:pS0A6cr4aHYZnYwC7Uw+rwgb39+nzkm2QhwZ+S6Gn5I=
 github.com/jordan-wright/email v0.0.0-20200824153738-3f5bafa1cd84/go.mod h1:1c7szIrayyPPB/987hsnvNzLushdWf4o/79s3P08L8A=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -298,12 +296,6 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
-github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc h1:RKf14vYWi2ttpEmkA4aQ3j4u9dStX2t4M8UM6qqNsG8=
-github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc/go.mod h1:kopuH9ugFRkIXf3YoqHKyrJ9YfUFsckUU9S7B+XP+is=
-github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible h1:Y6sqxHMyB1D2YSzWkLibYKgg+SwmyFU9dF2hn6MdTj4=
-github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible/go.mod h1:ZQnN8lSECaebrkQytbHj4xNgtg8CR7RYXnPok8e0EHA=
-github.com/lestrrat-go/strftime v1.0.6 h1:CFGsDEt1pOpFNU+TJB0nhz9jl+K0hZSLE205AhTIGQQ=
-github.com/lestrrat-go/strftime v1.0.6/go.mod h1:f7jQKgV5nnJpYgdEasS+/y7EsTb8ykN2z68n3TtcTaw=
 github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=


### PR DESCRIPTION
- 去掉 github.com/lestrrat-go/file-rotatelogs 库的依赖
- 实现zap.String(…"business", "xx")自定义业务日志数据路径, 输出文件路径为./global.GVA_CONFIG.Zap.Director/2006-01-02/xx/level(debug, info, warn, error, dpanic, panic, fatal).log