### PR TITLE
fix 调用respPool.Put归还对象前清空对象会造成下次调用无法copy

### DIFF
--- a/server/utils/captcha/redis.go
+++ b/server/utils/captcha/redis.go
@@ -13,6 +13,7 @@ func NewDefaultRedisStore() *RedisStore {
 	return &RedisStore{
 		Expiration: time.Second * 180,
 		PreKey:     "CAPTCHA_",
+		Context:    context.TODO(),
 	}
 }
 


### PR DESCRIPTION
operation.go: fix 调用respPool.Put归还对象前清空对象会造成下次调用无法copy
redis.go: fix NewDefaultRedisStore方法实例化的对象直接使用会造成空指针异常