### PR TITLE
Aviod panic if package is null

### DIFF
--- a/server/service/system/sys_auto_code.go
+++ b/server/service/system/sys_auto_code.go
@@ -277,6 +277,10 @@ func (autoCodeService *AutoCodeService) CreateTemp(autoCode system.AutoCodeStruc
 		return err
 	}
 	meta, _ := json.Marshal(autoCode)
+	// 增加判断：Package不为空
+	if autoCode.Package == "" {
+		return errors.New("Package为空\n")
+	}
 	// 写入文件前，先创建文件夹
 	if err = utils.CreateDir(needMkdir...); err != nil {
 		return err


### PR DESCRIPTION
当我在使用自动化代码功能时，发现Package如果为空会导致不可预期的情况。
- panic
- 后台生成非预期的代码文件
非预期的代码及文件：
```text
func RegisterTables() {
	db := global.GVA_DB
	err := db.AutoMigrate(
		example.ExaFileUploadAndDownload{},  .BareMetal{},  //异常
	)
}
```
![image](https://github.com/flipped-aurora/gin-vue-admin/assets/41617636/c771e244-5884-4a92-9071-499989d68b00)

panic内容：
```text
2023/10/11 09:25:01 [Recovery] 2023/10/11 - 09:25:01 panic recovered:
POST /autoCode/createTemp HTTP/1.1
Host: 127.0.0.1:8888
Accept: application/json, text/plain, */*
Accept-Encoding: gzip, deflate, br
Accept-Language: zh-CN,zh;q=0.9
Connection: close
Content-Length: 4488
Content-Type: application/json
Origin: http://localhost:8080
Referer: http://localhost:8080/
Sec-Ch-Ua: "Chromium";v="116", "Not)A;Brand";v="24", "Google Chrome";v="116"
Sec-Ch-Ua-Mobile: ?0
Sec-Ch-Ua-Platform: "macOS"
Sec-Fetch-Dest: empty
Sec-Fetch-Mode: cors
Sec-Fetch-Site: same-origin
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36
X-Token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVVUlEIjoiMTk4OTE0ZjItNWI4Ny00NjYxLTkwYWEtYzExZmI5MTEzY2YyIiwiSUQiOjEsIlVzZXJuYW1lIjoiYWRtaW4iLCJOaWNrTmFtZSI6ImFkbWluIiwiQXV0aG9yaXR5SWQiOjg4OCwiQnVmZmVyVGltZSI6ODY0MDAsImlzcyI6InFtUGx1cyIsImF1ZCI6WyJHVkEiXSwiZXhwIjoxNjk3NDQ3NTEzLCJuYmYiOjE2OTY4NDI3MTN9.-OLdchlJgMH3a7T4Yb7g5VA7n62RjbHIrzsQCZ85jc4
X-User-Id: 1


runtime error: slice bounds out of range [:1] with length 0
/usr/local/go/src/runtime/panic.go:128 (0x100e1ff7f)
        goPanicSliceAlen: panic(boundsError{x: int64(x), signed: true, y: y, code: boundsSliceAlen})
/Users/dingying/Documents/GolandProjects/gin-vue-admin/server/utils/ast/ast_router.go:32 (0x1018952fb)
        AddRouterCode: pkName := strings.ToUpper(pk[:1]) + pk[1:]
/Users/dingying/Documents/GolandProjects/gin-vue-admin/server/service/system/sys_auto_code.go:338 (0x1018a692b)
        (*AutoCodeService).CreateTemp: ast2.AddRouterCode(path, "Routers", autoCode.Package, autoCode.StructName)
/Users/dingying/Documents/GolandProjects/gin-vue-admin/server/api/v1/system/sys_auto_code.go:80 (0x101c1d617)
        (*AutoCodeApi).CreateTemp: err := autoCodeService.CreateTemp(a, apiIds...)
/Users/dingying/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x101833aab)
        (*Context).Next: c.handlers[c.index](c)
/Users/dingying/Documents/GolandProjects/gin-vue-admin/server/middleware/casbin_rbac.go:36 (0x101c45f87)
        Routers.CasbinHandler.func3: c.Next()
/Users/dingying/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x101833aab)
        (*Context).Next: c.handlers[c.index](c)
/Users/dingying/Documents/GolandProjects/gin-vue-admin/server/middleware/jwt.go:77 (0x101c45d57)
        Routers.JWTAuth.func2: c.Next()
/Users/dingying/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x10183fc4f)
        (*Context).Next: c.handlers[c.index](c)
/Users/dingying/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/recovery.go:102 (0x10183fc34)
        CustomRecoveryWithWriter.func1: c.Next()
/Users/dingying/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x10183efef)
        (*Context).Next: c.handlers[c.index](c)
/Users/dingying/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/logger.go:240 (0x10183efc0)
        LoggerWithConfig.func1: c.Next()
/Users/dingying/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x10183e123)
        (*Context).Next: c.handlers[c.index](c)
/Users/dingying/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:620 (0x10183de4c)
        (*Engine).handleHTTPRequest: c.Next()
/Users/dingying/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:576 (0x10183da6f)
        (*Engine).ServeHTTP: engine.handleHTTPRequest(c)
/usr/local/go/src/net/http/server.go:2938 (0x1010d7ddb)
        serverHandler.ServeHTTP: handler.ServeHTTP(rw, req)
/usr/local/go/src/net/http/server.go:2009 (0x1010d41d7)
        (*conn).serve: serverHandler{c.server}.ServeHTTP(w, w.req)
/usr/local/go/src/runtime/asm_arm64.s:1197 (0x100e56543)
        goexit: MOVD    R0, R0  // NOP
```