### PR TITLE
fix: 初始化库时根据RouterPrefix自动生成相关路径

### DIFF
--- a/server/source/system/api.go
+++ b/server/source/system/api.go
@@ -2,8 +2,10 @@ package system
 
 import (
 	"context"
+
 	sysModel "github.com/flipped-aurora/gin-vue-admin/server/model/system"
 	"github.com/flipped-aurora/gin-vue-admin/server/service/system"
+	"github.com/flipped-aurora/gin-vue-admin/server/utils"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -159,6 +161,8 @@ func (i *initApi) InitializeData(ctx context.Context) (context.Context, error) {
 		{ApiGroup: "导出模板", Method: "GET", Path: "/sysExportTemplate/getSysExportTemplateList", Description: "获取导出模板列表"},
 		{ApiGroup: "导出模板", Method: "GET", Path: "/sysExportTemplate/exportExcel", Description: "导出Excel"},
 	}
+
+	utils.FixRouterPrefix_SysApi(entities)
 	if err := db.Create(&entities).Error; err != nil {
 		return ctx, errors.Wrap(err, sysModel.SysApi{}.TableName()+"表数据初始化失败!")
 	}

--- a/server/source/system/casbin.go
+++ b/server/source/system/casbin.go
@@ -5,6 +5,7 @@ import (
 
 	adapter "github.com/casbin/gorm-adapter/v3"
 	"github.com/flipped-aurora/gin-vue-admin/server/service/system"
+	"github.com/flipped-aurora/gin-vue-admin/server/utils"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -241,6 +242,7 @@ func (i *initCasbin) InitializeData(ctx context.Context) (context.Context, error
 		{Ptype: "p", V0: "9528", V1: "/autoCode/createTemp", V2: "POST"},
 		{Ptype: "p", V0: "9528", V1: "/user/getUserInfo", V2: "GET"},
 	}
+	utils.FixRouterPrefix_CasbinRule(entities)
 	if err := db.Create(&entities).Error; err != nil {
 		return ctx, errors.Wrap(err, "Casbin 表 ("+i.InitializerName()+") 数据初始化失败!")
 	}

--- a/server/utils/fix_routerprefix.go
+++ b/server/utils/fix_routerprefix.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	adapter "github.com/casbin/gorm-adapter/v3"
+	"github.com/flipped-aurora/gin-vue-admin/server/global"
+	sysModel "github.com/flipped-aurora/gin-vue-admin/server/model/system"
+)
+
+func routerprefix() string {
+	prefix := global.GVA_CONFIG.System.RouterPrefix
+	if prefix != "" && !strings.HasPrefix(prefix, "/") {
+		prefix = fmt.Sprintf("/%s", prefix)
+	}
+	return prefix
+}
+
+func FixRouterPrefix_CasbinRule(ruleList []adapter.CasbinRule) {
+	routerprefix := routerprefix()
+	for idx, rule := range ruleList {
+		ruleList[idx].V1, _ = url.JoinPath(routerprefix, rule.V1)
+	}
+}
+
+func FixRouterPrefix_SysApi(apiList []sysModel.SysApi) {
+	routerprefix := routerprefix()
+	for idx, api := range apiList {
+		apiList[idx].Path, _ = url.JoinPath(routerprefix, api.Path)
+	}
+}


### PR DESCRIPTION
修改了初始化项目时的路径配置，自动添加RouterPrefix