### PR TITLE
解决drawer和dialog层级冲突问题

### DIFF
--- a/web/src/view/superAdmin/user/user.vue
+++ b/web/src/view/superAdmin/user/user.vue
@@ -236,6 +236,11 @@
                 v-else
                 class="header-img-box"
               >从媒体库选择</div>
+              <ChooseImg
+                ref="chooseImg"
+                :target="userInfo"
+                :target-key="`headerImg`"
+              />
             </div>
           </el-form-item>
 
@@ -253,14 +258,8 @@
         </div>
       </template>
     </el-dialog>
-    <ChooseImg
-      ref="chooseImg"
-      :target="userInfo"
-      :target-key="`headerImg`"
-    />
   </div>
 </template>
-
 
 <script setup>
 


### PR DESCRIPTION
![image](https://github.com/flipped-aurora/gin-vue-admin/assets/56824280/f52411c7-1427-4a7e-8b8f-153f442b274a)
修改头像打开素材库时层级错误，drawer应该在dialog的上方