### PR TITLE
fix: 解决build时，会有浏览器缓存问题。

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -43,9 +43,9 @@ export default ({
 
   const rollupOptions = {
     output: {
-      entryFileNames: 'assets/087AC4D233B64EB0[name].js',
-      chunkFileNames: 'assets/087AC4D233B64EB0[name].js',
-      assetFileNames: 'assets/087AC4D233B64EB0[name].[ext]',
+      entryFileNames: 'assets/087AC4D233B64EB0[name].[hash].js',
+      chunkFileNames: 'assets/087AC4D233B64EB0[name].[hash].js',
+      assetFileNames: 'assets/087AC4D233B64EB0[name].[hash].[ext]',
     },
   }
 


### PR DESCRIPTION
fix: 解决build时，会有浏览器缓存问题。


我在使用最新版本的代码时，发现打包配置添加了`rollupOptions`，多了一个`087AC4D233B64EB0`，我没去回顾commit，但我尊重原代码。不过这样会造成生产环境的浏览器缓存问题。我添加了hash来避免这个问题。