### PR TITLE
fixed:  api管理中删除的 popover 触发改为 click

### DIFF
--- a/web/src/view/superAdmin/api/api.vue
+++ b/web/src/view/superAdmin/api/api.vue
@@ -66,6 +66,7 @@
           v-model="deleteVisible"
           placement="top"
           width="160"
+          trigger="click"
         >
           <p>确定要删除吗？</p>
           <div style="text-align: right; margin-top: 8px;">


### PR DESCRIPTION
popover默认为hover，鼠标略过的时候，会直接弹出气泡，并且此时还可以直接对气泡内的按钮进行操作，不太符合操作逻辑
原来的：
![20240311191557_rec_](https://github.com/flipped-aurora/gin-vue-admin/assets/54276203/681d3599-3d70-4a7e-82f1-3c69995acb6b)
修改后：
![20240311191725_rec_](https://github.com/flipped-aurora/gin-vue-admin/assets/54276203/8692a118-6b03-4994-8642-1000a702164f)
