### PR TITLE
多文件: 菜单parentId由string改成uint

### DIFF
--- a/server/model/system/request/sys_menu.go
+++ b/server/model/system/request/sys_menu.go
@@ -14,7 +14,7 @@ type AddMenuAuthorityInfo struct {
 func DefaultMenu() []system.SysBaseMenu {
 	return []system.SysBaseMenu{{
 		GVA_MODEL: global.GVA_MODEL{ID: 1},
-		ParentId:  "0",
+		ParentId:  0,
 		Path:      "dashboard",
 		Name:      "dashboard",
 		Component: "view/dashboard/index.vue",

--- a/server/model/system/sys_authority_menu.go
+++ b/server/model/system/sys_authority_menu.go
@@ -2,7 +2,7 @@ package system
 
 type SysMenu struct {
 	SysBaseMenu
-	MenuId      string                 `json:"menuId" gorm:"comment:菜单ID"`
+	MenuId      uint                   `json:"menuId" gorm:"comment:菜单ID"`
 	AuthorityId uint                   `json:"-" gorm:"comment:角色ID"`
 	Children    []SysMenu              `json:"children" gorm:"-"`
 	Parameters  []SysBaseMenuParameter `json:"parameters" gorm:"foreignKey:SysBaseMenuID;references:MenuId"`

--- a/server/model/system/sys_base_menu.go
+++ b/server/model/system/sys_base_menu.go
@@ -6,34 +6,34 @@ import (
 
 type SysBaseMenu struct {
 	global.GVA_MODEL
-	MenuLevel     uint                   `json:"-"`
-	ParentId      string                 `json:"parentId" gorm:"comment:父菜单ID"`          // 父菜单ID
-	Path          string                 `json:"path" gorm:"comment:路由path"`              // 路由path
-	Name          string                 `json:"name" gorm:"comment:路由name"`              // 路由name
-	Hidden        bool                   `json:"hidden" gorm:"comment:是否在列表隐藏"`      // 是否在列表隐藏
-	Component     string                 `json:"component" gorm:"comment:对应前端文件路径"` // 对应前端文件路径
-	Sort          int                    `json:"sort" gorm:"comment:排序标记"`              // 排序标记
-	Meta          `json:"meta" gorm:"embedded;comment:附加属性"`                            // 附加属性
-	SysAuthoritys []SysAuthority         `json:"authoritys" gorm:"many2many:sys_authority_menus;"`
-	Children      []SysBaseMenu          `json:"children" gorm:"-"`
-	Parameters    []SysBaseMenuParameter `json:"parameters"`
-	MenuBtn       []SysBaseMenuBtn       `json:"menuBtn"`
+	MenuLevel     uint                                       `json:"-"`
+	ParentId      uint                                       `json:"parentId" gorm:"comment:父菜单ID"`     // 父菜单ID
+	Path          string                                     `json:"path" gorm:"comment:路由path"`        // 路由path
+	Name          string                                     `json:"name" gorm:"comment:路由name"`        // 路由name
+	Hidden        bool                                       `json:"hidden" gorm:"comment:是否在列表隐藏"`     // 是否在列表隐藏
+	Component     string                                     `json:"component" gorm:"comment:对应前端文件路径"` // 对应前端文件路径
+	Sort          int                                        `json:"sort" gorm:"comment:排序标记"`          // 排序标记
+	Meta          `json:"meta" gorm:"embedded;comment:附加属性"` // 附加属性
+	SysAuthoritys []SysAuthority                             `json:"authoritys" gorm:"many2many:sys_authority_menus;"`
+	Children      []SysBaseMenu                              `json:"children" gorm:"-"`
+	Parameters    []SysBaseMenuParameter                     `json:"parameters"`
+	MenuBtn       []SysBaseMenuBtn                           `json:"menuBtn"`
 }
 
 type Meta struct {
 	ActiveName  string `json:"activeName" gorm:"comment:高亮菜单"`
-	KeepAlive   bool   `json:"keepAlive" gorm:"comment:是否缓存"`                 // 是否缓存
+	KeepAlive   bool   `json:"keepAlive" gorm:"comment:是否缓存"`           // 是否缓存
 	DefaultMenu bool   `json:"defaultMenu" gorm:"comment:是否是基础路由（开发中）"` // 是否是基础路由（开发中）
-	Title       string `json:"title" gorm:"comment:菜单名"`                       // 菜单名
-	Icon        string `json:"icon" gorm:"comment:菜单图标"`                      // 菜单图标
-	CloseTab    bool   `json:"closeTab" gorm:"comment:自动关闭tab"`               // 自动关闭tab
+	Title       string `json:"title" gorm:"comment:菜单名"`                // 菜单名
+	Icon        string `json:"icon" gorm:"comment:菜单图标"`                // 菜单图标
+	CloseTab    bool   `json:"closeTab" gorm:"comment:自动关闭tab"`         // 自动关闭tab
 }
 
 type SysBaseMenuParameter struct {
 	global.GVA_MODEL
 	SysBaseMenuID uint
 	Type          string `json:"type" gorm:"comment:地址栏携带参数为params还是query"` // 地址栏携带参数为params还是query
-	Key           string `json:"key" gorm:"comment:地址栏携带参数的key"`              // 地址栏携带参数的key
+	Key           string `json:"key" gorm:"comment:地址栏携带参数的key"`            // 地址栏携带参数的key
 	Value         string `json:"value" gorm:"comment:地址栏携带参数的值"`            // 地址栏携带参数的值
 }
 

--- a/server/plugin/plugin-tool/utils/check.go
+++ b/server/plugin/plugin-tool/utils/check.go
@@ -2,9 +2,9 @@ package utils
 
 import (
 	"fmt"
+
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/system"
-	"strconv"
 )
 
 func RegisterApis(apis ...system.SysApi) {
@@ -37,13 +37,13 @@ func RegisterMenus(menus ...system.SysBaseMenu) {
 		fmt.Println("插件已安装或存在同名菜单")
 		return
 	}
-	parentMenu.ParentId = "0"
+	parentMenu.ParentId = 0
 	err := global.GVA_DB.Create(&parentMenu).Error
 	if err != nil {
 		fmt.Println(err)
 	}
 	for i := range otherMenus {
-		pid := strconv.Itoa(int(parentMenu.ID))
+		pid := parentMenu.ID
 		otherMenus[i].ParentId = pid
 	}
 	err = global.GVA_DB.Create(&otherMenus).Error

--- a/server/service/system/sys_authority.go
+++ b/server/service/system/sys_authority.go
@@ -70,7 +70,7 @@ func (authorityService *AuthorityService) CopyAuthority(copyInfo response.SysAut
 	}
 	var baseMenu []system.SysBaseMenu
 	for _, v := range menus {
-		intNum, _ := strconv.Atoi(v.MenuId)
+		intNum := v.MenuId
 		v.SysBaseMenu.ID = uint(intNum)
 		baseMenu = append(baseMenu, v.SysBaseMenu)
 	}

--- a/server/service/system/sys_auto_code.go
+++ b/server/service/system/sys_auto_code.go
@@ -578,7 +578,7 @@ func (autoCodeService *AutoCodeService) AutoCreateMenu(a *system.AutoCodeStruct)
 	if err == nil {
 		return 0, errors.New("存在相同的菜单路由，请关闭自动创建菜单功能")
 	}
-	menu.ParentId = "0"
+	menu.ParentId = 0
 	menu.Name = a.Abbreviation
 	menu.Path = a.Abbreviation
 	menu.Meta.Title = a.Description

--- a/server/service/system/sys_menu.go
+++ b/server/service/system/sys_menu.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"errors"
-	"strconv"
 
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/common/request"
@@ -20,11 +19,11 @@ type MenuService struct{}
 
 var MenuServiceApp = new(MenuService)
 
-func (menuService *MenuService) getMenuTreeMap(authorityId uint) (treeMap map[string][]system.SysMenu, err error) {
+func (menuService *MenuService) getMenuTreeMap(authorityId uint) (treeMap map[uint][]system.SysMenu, err error) {
 	var allMenus []system.SysMenu
 	var baseMenu []system.SysBaseMenu
 	var btns []system.SysAuthorityBtn
-	treeMap = make(map[string][]system.SysMenu)
+	treeMap = make(map[uint][]system.SysMenu)
 
 	var SysAuthorityMenus []system.SysAuthorityMenu
 	err = global.GVA_DB.Where("sys_authority_authority_id = ?", authorityId).Find(&SysAuthorityMenus).Error
@@ -47,7 +46,7 @@ func (menuService *MenuService) getMenuTreeMap(authorityId uint) (treeMap map[st
 		allMenus = append(allMenus, system.SysMenu{
 			SysBaseMenu: baseMenu[i],
 			AuthorityId: authorityId,
-			MenuId:      strconv.Itoa(int(baseMenu[i].ID)),
+			MenuId:      baseMenu[i].ID,
 			Parameters:  baseMenu[i].Parameters,
 		})
 	}
@@ -78,7 +77,7 @@ func (menuService *MenuService) getMenuTreeMap(authorityId uint) (treeMap map[st
 
 func (menuService *MenuService) GetMenuTree(authorityId uint) (menus []system.SysMenu, err error) {
 	menuTree, err := menuService.getMenuTreeMap(authorityId)
-	menus = menuTree["0"]
+	menus = menuTree[0]
 	for i := 0; i < len(menus); i++ {
 		err = menuService.getChildrenList(&menus[i], menuTree)
 	}
@@ -91,7 +90,7 @@ func (menuService *MenuService) GetMenuTree(authorityId uint) (menus []system.Sy
 //@param: menu *model.SysMenu, treeMap map[string][]model.SysMenu
 //@return: err error
 
-func (menuService *MenuService) getChildrenList(menu *system.SysMenu, treeMap map[string][]system.SysMenu) (err error) {
+func (menuService *MenuService) getChildrenList(menu *system.SysMenu, treeMap map[uint][]system.SysMenu) (err error) {
 	menu.Children = treeMap[menu.MenuId]
 	for i := 0; i < len(menu.Children); i++ {
 		err = menuService.getChildrenList(&menu.Children[i], treeMap)
@@ -107,7 +106,7 @@ func (menuService *MenuService) getChildrenList(menu *system.SysMenu, treeMap ma
 func (menuService *MenuService) GetInfoList() (list interface{}, total int64, err error) {
 	var menuList []system.SysBaseMenu
 	treeMap, err := menuService.getBaseMenuTreeMap()
-	menuList = treeMap["0"]
+	menuList = treeMap[0]
 	for i := 0; i < len(menuList); i++ {
 		err = menuService.getBaseChildrenList(&menuList[i], treeMap)
 	}
@@ -120,8 +119,8 @@ func (menuService *MenuService) GetInfoList() (list interface{}, total int64, er
 //@param: menu *model.SysBaseMenu, treeMap map[string][]model.SysBaseMenu
 //@return: err error
 
-func (menuService *MenuService) getBaseChildrenList(menu *system.SysBaseMenu, treeMap map[string][]system.SysBaseMenu) (err error) {
-	menu.Children = treeMap[strconv.Itoa(int(menu.ID))]
+func (menuService *MenuService) getBaseChildrenList(menu *system.SysBaseMenu, treeMap map[uint][]system.SysBaseMenu) (err error) {
+	menu.Children = treeMap[menu.ID]
 	for i := 0; i < len(menu.Children); i++ {
 		err = menuService.getBaseChildrenList(&menu.Children[i], treeMap)
 	}
@@ -146,9 +145,9 @@ func (menuService *MenuService) AddBaseMenu(menu system.SysBaseMenu) error {
 //@description: 获取路由总树map
 //@return: treeMap map[string][]system.SysBaseMenu, err error
 
-func (menuService *MenuService) getBaseMenuTreeMap() (treeMap map[string][]system.SysBaseMenu, err error) {
+func (menuService *MenuService) getBaseMenuTreeMap() (treeMap map[uint][]system.SysBaseMenu, err error) {
 	var allMenus []system.SysBaseMenu
-	treeMap = make(map[string][]system.SysBaseMenu)
+	treeMap = make(map[uint][]system.SysBaseMenu)
 	err = global.GVA_DB.Order("sort").Preload("MenuBtn").Preload("Parameters").Find(&allMenus).Error
 	for _, v := range allMenus {
 		treeMap[v.ParentId] = append(treeMap[v.ParentId], v)
@@ -163,7 +162,7 @@ func (menuService *MenuService) getBaseMenuTreeMap() (treeMap map[string][]syste
 
 func (menuService *MenuService) GetBaseMenuTree() (menus []system.SysBaseMenu, err error) {
 	treeMap, err := menuService.getBaseMenuTreeMap()
-	menus = treeMap["0"]
+	menus = treeMap[0]
 	for i := 0; i < len(menus); i++ {
 		err = menuService.getBaseChildrenList(&menus[i], treeMap)
 	}
@@ -210,7 +209,7 @@ func (menuService *MenuService) GetMenuAuthority(info *request.GetAuthorityId) (
 		menus = append(menus, system.SysMenu{
 			SysBaseMenu: baseMenu[i],
 			AuthorityId: info.AuthorityId,
-			MenuId:      strconv.Itoa(int(baseMenu[i].ID)),
+			MenuId:      baseMenu[i].ID,
 			Parameters:  baseMenu[i].Parameters,
 		})
 	}
@@ -218,6 +217,7 @@ func (menuService *MenuService) GetMenuAuthority(info *request.GetAuthorityId) (
 }
 
 // UserAuthorityDefaultRouter 用户角色默认路由检查
+//
 //	Author [SliverHorn](https://github.com/SliverHorn)
 func (menuService *MenuService) UserAuthorityDefaultRouter(user *system.SysUser) {
 	var menuIds []string

--- a/server/source/system/menu.go
+++ b/server/source/system/menu.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"context"
+
 	. "github.com/flipped-aurora/gin-vue-admin/server/model/system"
 	"github.com/flipped-aurora/gin-vue-admin/server/service/system"
 	"github.com/pkg/errors"
@@ -50,36 +51,36 @@ func (i *initMenu) InitializeData(ctx context.Context) (next context.Context, er
 		return ctx, system.ErrMissingDBContext
 	}
 	entities := []SysBaseMenu{
-		{MenuLevel: 0, Hidden: false, ParentId: "0", Path: "dashboard", Name: "dashboard", Component: "view/dashboard/index.vue", Sort: 1, Meta: Meta{Title: "仪表盘", Icon: "odometer"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "0", Path: "about", Name: "about", Component: "view/about/index.vue", Sort: 9, Meta: Meta{Title: "关于我们", Icon: "info-filled"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "0", Path: "admin", Name: "superAdmin", Component: "view/superAdmin/index.vue", Sort: 3, Meta: Meta{Title: "超级管理员", Icon: "user"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "3", Path: "authority", Name: "authority", Component: "view/superAdmin/authority/authority.vue", Sort: 1, Meta: Meta{Title: "角色管理", Icon: "avatar"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "3", Path: "menu", Name: "menu", Component: "view/superAdmin/menu/menu.vue", Sort: 2, Meta: Meta{Title: "菜单管理", Icon: "tickets", KeepAlive: true}},
-		{MenuLevel: 0, Hidden: false, ParentId: "3", Path: "api", Name: "api", Component: "view/superAdmin/api/api.vue", Sort: 3, Meta: Meta{Title: "api管理", Icon: "platform", KeepAlive: true}},
-		{MenuLevel: 0, Hidden: false, ParentId: "3", Path: "user", Name: "user", Component: "view/superAdmin/user/user.vue", Sort: 4, Meta: Meta{Title: "用户管理", Icon: "coordinate"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "3", Path: "dictionary", Name: "dictionary", Component: "view/superAdmin/dictionary/sysDictionary.vue", Sort: 5, Meta: Meta{Title: "字典管理", Icon: "notebook"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "3", Path: "operation", Name: "operation", Component: "view/superAdmin/operation/sysOperationRecord.vue", Sort: 6, Meta: Meta{Title: "操作历史", Icon: "pie-chart"}},
-		{MenuLevel: 0, Hidden: true, ParentId: "0", Path: "person", Name: "person", Component: "view/person/person.vue", Sort: 4, Meta: Meta{Title: "个人信息", Icon: "message"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "0", Path: "example", Name: "example", Component: "view/example/index.vue", Sort: 7, Meta: Meta{Title: "示例文件", Icon: "management"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "11", Path: "upload", Name: "upload", Component: "view/example/upload/upload.vue", Sort: 5, Meta: Meta{Title: "媒体库（上传下载）", Icon: "upload"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "11", Path: "breakpoint", Name: "breakpoint", Component: "view/example/breakpoint/breakpoint.vue", Sort: 6, Meta: Meta{Title: "断点续传", Icon: "upload-filled"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "11", Path: "customer", Name: "customer", Component: "view/example/customer/customer.vue", Sort: 7, Meta: Meta{Title: "客户列表（资源示例）", Icon: "avatar"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "0", Path: "systemTools", Name: "systemTools", Component: "view/systemTools/index.vue", Sort: 5, Meta: Meta{Title: "系统工具", Icon: "tools"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "15", Path: "autoCode", Name: "autoCode", Component: "view/systemTools/autoCode/index.vue", Sort: 1, Meta: Meta{Title: "代码生成器", Icon: "cpu", KeepAlive: true}},
-		{MenuLevel: 0, Hidden: false, ParentId: "15", Path: "formCreate", Name: "formCreate", Component: "view/systemTools/formCreate/index.vue", Sort: 2, Meta: Meta{Title: "表单生成器", Icon: "magic-stick", KeepAlive: true}},
-		{MenuLevel: 0, Hidden: false, ParentId: "15", Path: "system", Name: "system", Component: "view/systemTools/system/system.vue", Sort: 3, Meta: Meta{Title: "系统配置", Icon: "operation"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "15", Path: "autoCodeAdmin", Name: "autoCodeAdmin", Component: "view/systemTools/autoCodeAdmin/index.vue", Sort: 1, Meta: Meta{Title: "自动化代码管理", Icon: "magic-stick"}},
-		{MenuLevel: 0, Hidden: true, ParentId: "15", Path: "autoCodeEdit/:id", Name: "autoCodeEdit", Component: "view/systemTools/autoCode/index.vue", Sort: 0, Meta: Meta{Title: "自动化代码-${id}", Icon: "magic-stick"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "15", Path: "autoPkg", Name: "autoPkg", Component: "view/systemTools/autoPkg/autoPkg.vue", Sort: 0, Meta: Meta{Title: "自动化package", Icon: "folder"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "0", Path: "https://www.gin-vue-admin.com", Name: "https://www.gin-vue-admin.com", Component: "/", Sort: 0, Meta: Meta{Title: "官方网站", Icon: "customer-gva"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "0", Path: "state", Name: "state", Component: "view/system/state.vue", Sort: 8, Meta: Meta{Title: "服务器状态", Icon: "cloudy"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "0", Path: "plugin", Name: "plugin", Component: "view/routerHolder.vue", Sort: 6, Meta: Meta{Title: "插件系统", Icon: "cherry"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "24", Path: "https://plugin.gin-vue-admin.com/", Name: "https://plugin.gin-vue-admin.com/", Component: "https://plugin.gin-vue-admin.com/", Sort: 0, Meta: Meta{Title: "插件市场", Icon: "shop"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "24", Path: "installPlugin", Name: "installPlugin", Component: "view/systemTools/installPlugin/index.vue", Sort: 1, Meta: Meta{Title: "插件安装", Icon: "box"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "24", Path: "autoPlug", Name: "autoPlug", Component: "view/systemTools/autoPlug/autoPlug.vue", Sort: 2, Meta: Meta{Title: "插件模板", Icon: "folder"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "24", Path: "pubPlug", Name: "pubPlug", Component: "view/systemTools/pubPlug/pubPlug.vue", Sort: 3, Meta: Meta{Title: "打包插件", Icon: "files"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "24", Path: "plugin-email", Name: "plugin-email", Component: "plugin/email/view/index.vue", Sort: 4, Meta: Meta{Title: "邮件插件", Icon: "message"}},
-		{MenuLevel: 0, Hidden: false, ParentId: "15", Path: "exportTemplate", Name: "exportTemplate", Component: "view/systemTools/exportTemplate/exportTemplate.vue", Sort: 10, Meta: Meta{Title: "表格模板", Icon: "reading"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 0, Path: "dashboard", Name: "dashboard", Component: "view/dashboard/index.vue", Sort: 1, Meta: Meta{Title: "仪表盘", Icon: "odometer"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 0, Path: "about", Name: "about", Component: "view/about/index.vue", Sort: 9, Meta: Meta{Title: "关于我们", Icon: "info-filled"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 0, Path: "admin", Name: "superAdmin", Component: "view/superAdmin/index.vue", Sort: 3, Meta: Meta{Title: "超级管理员", Icon: "user"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 3, Path: "authority", Name: "authority", Component: "view/superAdmin/authority/authority.vue", Sort: 1, Meta: Meta{Title: "角色管理", Icon: "avatar"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 3, Path: "menu", Name: "menu", Component: "view/superAdmin/menu/menu.vue", Sort: 2, Meta: Meta{Title: "菜单管理", Icon: "tickets", KeepAlive: true}},
+		{MenuLevel: 0, Hidden: false, ParentId: 3, Path: "api", Name: "api", Component: "view/superAdmin/api/api.vue", Sort: 3, Meta: Meta{Title: "api管理", Icon: "platform", KeepAlive: true}},
+		{MenuLevel: 0, Hidden: false, ParentId: 3, Path: "user", Name: "user", Component: "view/superAdmin/user/user.vue", Sort: 4, Meta: Meta{Title: "用户管理", Icon: "coordinate"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 3, Path: "dictionary", Name: "dictionary", Component: "view/superAdmin/dictionary/sysDictionary.vue", Sort: 5, Meta: Meta{Title: "字典管理", Icon: "notebook"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 3, Path: "operation", Name: "operation", Component: "view/superAdmin/operation/sysOperationRecord.vue", Sort: 6, Meta: Meta{Title: "操作历史", Icon: "pie-chart"}},
+		{MenuLevel: 0, Hidden: true, ParentId: 0, Path: "person", Name: "person", Component: "view/person/person.vue", Sort: 4, Meta: Meta{Title: "个人信息", Icon: "message"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 0, Path: "example", Name: "example", Component: "view/example/index.vue", Sort: 7, Meta: Meta{Title: "示例文件", Icon: "management"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 11, Path: "upload", Name: "upload", Component: "view/example/upload/upload.vue", Sort: 5, Meta: Meta{Title: "媒体库（上传下载）", Icon: "upload"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 11, Path: "breakpoint", Name: "breakpoint", Component: "view/example/breakpoint/breakpoint.vue", Sort: 6, Meta: Meta{Title: "断点续传", Icon: "upload-filled"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 11, Path: "customer", Name: "customer", Component: "view/example/customer/customer.vue", Sort: 7, Meta: Meta{Title: "客户列表（资源示例）", Icon: "avatar"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 0, Path: "systemTools", Name: "systemTools", Component: "view/systemTools/index.vue", Sort: 5, Meta: Meta{Title: "系统工具", Icon: "tools"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 15, Path: "autoCode", Name: "autoCode", Component: "view/systemTools/autoCode/index.vue", Sort: 1, Meta: Meta{Title: "代码生成器", Icon: "cpu", KeepAlive: true}},
+		{MenuLevel: 0, Hidden: false, ParentId: 15, Path: "formCreate", Name: "formCreate", Component: "view/systemTools/formCreate/index.vue", Sort: 2, Meta: Meta{Title: "表单生成器", Icon: "magic-stick", KeepAlive: true}},
+		{MenuLevel: 0, Hidden: false, ParentId: 15, Path: "system", Name: "system", Component: "view/systemTools/system/system.vue", Sort: 3, Meta: Meta{Title: "系统配置", Icon: "operation"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 15, Path: "autoCodeAdmin", Name: "autoCodeAdmin", Component: "view/systemTools/autoCodeAdmin/index.vue", Sort: 1, Meta: Meta{Title: "自动化代码管理", Icon: "magic-stick"}},
+		{MenuLevel: 0, Hidden: true, ParentId: 15, Path: "autoCodeEdit/:id", Name: "autoCodeEdit", Component: "view/systemTools/autoCode/index.vue", Sort: 0, Meta: Meta{Title: "自动化代码-${id}", Icon: "magic-stick"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 15, Path: "autoPkg", Name: "autoPkg", Component: "view/systemTools/autoPkg/autoPkg.vue", Sort: 0, Meta: Meta{Title: "自动化package", Icon: "folder"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 0, Path: "https://www.gin-vue-admin.com", Name: "https://www.gin-vue-admin.com", Component: "/", Sort: 0, Meta: Meta{Title: "官方网站", Icon: "customer-gva"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 0, Path: "state", Name: "state", Component: "view/system/state.vue", Sort: 8, Meta: Meta{Title: "服务器状态", Icon: "cloudy"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 0, Path: "plugin", Name: "plugin", Component: "view/routerHolder.vue", Sort: 6, Meta: Meta{Title: "插件系统", Icon: "cherry"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 24, Path: "https://plugin.gin-vue-admin.com/", Name: "https://plugin.gin-vue-admin.com/", Component: "https://plugin.gin-vue-admin.com/", Sort: 0, Meta: Meta{Title: "插件市场", Icon: "shop"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 24, Path: "installPlugin", Name: "installPlugin", Component: "view/systemTools/installPlugin/index.vue", Sort: 1, Meta: Meta{Title: "插件安装", Icon: "box"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 24, Path: "autoPlug", Name: "autoPlug", Component: "view/systemTools/autoPlug/autoPlug.vue", Sort: 2, Meta: Meta{Title: "插件模板", Icon: "folder"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 24, Path: "pubPlug", Name: "pubPlug", Component: "view/systemTools/pubPlug/pubPlug.vue", Sort: 3, Meta: Meta{Title: "打包插件", Icon: "files"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 24, Path: "plugin-email", Name: "plugin-email", Component: "plugin/email/view/index.vue", Sort: 4, Meta: Meta{Title: "邮件插件", Icon: "message"}},
+		{MenuLevel: 0, Hidden: false, ParentId: 15, Path: "exportTemplate", Name: "exportTemplate", Component: "view/systemTools/exportTemplate/exportTemplate.vue", Sort: 10, Meta: Meta{Title: "表格模板", Icon: "reading"}},
 	}
 	if err = db.Create(&entities).Error; err != nil {
 		return ctx, errors.Wrap(err, SysBaseMenu{}.TableName()+"表数据初始化失败!")

--- a/web/src/view/superAdmin/menu/menu.vue
+++ b/web/src/view/superAdmin/menu/menu.vue
@@ -2,28 +2,23 @@
   <div>
     <div class="gva-table-box">
       <div class="gva-btn-list">
-        <el-button
-          type="primary"
-          icon="plus"
-          @click="addMenu('0')"
-        >新增根菜单</el-button>
+        <el-button type="primary" icon="plus" @click="addMenu('0')"
+          >新增根菜单</el-button
+        >
         <el-icon
           class="cursor-pointer"
-          @click="toDoc('https://www.bilibili.com/video/BV1kv4y1g7nT/?p=4&vd_source=f2640257c21e3b547a790461ed94875e')"
-        ><VideoCameraFilled /></el-icon>
+          @click="
+            toDoc(
+              'https://www.bilibili.com/video/BV1kv4y1g7nT/?p=4&vd_source=f2640257c21e3b547a790461ed94875e'
+            )
+          "
+          ><VideoCameraFilled
+        /></el-icon>
       </div>
 
       <!-- 由于此处菜单跟左侧列表一一对应所以不需要分页 pageSize默认999 -->
-      <el-table
-        :data="tableData"
-        row-key="ID"
-      >
-        <el-table-column
-          align="left"
-          label="ID"
-          min-width="100"
-          prop="ID"
-        />
+      <el-table :data="tableData" row-key="ID">
+        <el-table-column align="left" label="ID" min-width="100" prop="ID" />
         <el-table-column
           align="left"
           label="展示名称"
@@ -41,10 +36,7 @@
           prop="authorityName"
         >
           <template #default="scope">
-            <div
-              v-if="scope.row.meta.icon"
-              class="icon-column"
-            >
+            <div v-if="scope.row.meta.icon" class="icon-column">
               <el-icon>
                 <component :is="scope.row.meta.icon" />
               </el-icon>
@@ -73,7 +65,7 @@
           prop="hidden"
         >
           <template #default="scope">
-            <span>{{ scope.row.hidden?"隐藏":"显示" }}</span>
+            <span>{{ scope.row.hidden ? "隐藏" : "显示" }}</span>
           </template>
         </el-table-column>
         <el-table-column
@@ -82,44 +74,36 @@
           min-width="90"
           prop="parentId"
         />
-        <el-table-column
-          align="left"
-          label="排序"
-          min-width="70"
-          prop="sort"
-        />
+        <el-table-column align="left" label="排序" min-width="70" prop="sort" />
         <el-table-column
           align="left"
           label="文件路径"
           min-width="360"
           prop="component"
         />
-        <el-table-column
-          align="left"
-          fixed="right"
-          label="操作"
-          width="300"
-        >
+        <el-table-column align="left" fixed="right" label="操作" width="300">
           <template #default="scope">
             <el-button
               type="primary"
               link
               icon="plus"
               @click="addMenu(scope.row.ID)"
-            >添加子菜单</el-button>
+              >添加子菜单</el-button
+            >
             <el-button
               type="primary"
               link
               icon="edit"
               @click="editMenu(scope.row.ID)"
-            >编辑</el-button>
+              >编辑</el-button
+            >
             <el-button
-
               type="primary"
               link
               icon="delete"
               @click="deleteMenu(scope.row.ID)"
-            >删除</el-button>
+              >删除</el-button
+            >
           </template>
         </el-table-column>
       </el-table>
@@ -135,10 +119,7 @@
           <span class="text-lg">{{ dialogTitle }}</span>
           <div>
             <el-button @click="closeDialog">取 消</el-button>
-            <el-button
-              type="primary"
-              @click="enterDialog"
-            >确 定</el-button>
+            <el-button type="primary" @click="enterDialog">确 定</el-button>
           </div>
         </div>
       </template>
@@ -153,11 +134,7 @@
         label-position="top"
         label-width="85px"
       >
-        <el-form-item
-          label="路由Name"
-          prop="path"
-          style="width:30%"
-        >
+        <el-form-item label="路由Name" prop="path" style="width: 30%">
           <el-input
             v-model="form.name"
             autocomplete="off"
@@ -165,17 +142,15 @@
             @change="changeName"
           />
         </el-form-item>
-        <el-form-item
-          prop="path"
-          style="width:30%"
-        >
+        <el-form-item prop="path" style="width: 30%">
           <template #label>
-            <span style="display: inline-flex;align-items: center;">
+            <span style="display: inline-flex; align-items: center">
               <span>路由Path</span>
               <el-checkbox
                 v-model="checkFlag"
-                style="margin-left:12px;height: auto"
-              >添加参数</el-checkbox>
+                style="margin-left: 12px; height: auto"
+                >添加参数</el-checkbox
+              >
             </span>
           </template>
 
@@ -186,88 +161,54 @@
             placeholder="建议只在后方拼接参数"
           />
         </el-form-item>
-        <el-form-item
-          label="是否隐藏"
-          style="width:30%"
-        >
-          <el-select
-            v-model="form.hidden"
-            placeholder="是否在列表隐藏"
-          >
-            <el-option
-              :value="false"
-              label="否"
-            />
-            <el-option
-              :value="true"
-              label="是"
-            />
+        <el-form-item label="是否隐藏" style="width: 30%">
+          <el-select v-model="form.hidden" placeholder="是否在列表隐藏">
+            <el-option :value="false" label="否" />
+            <el-option :value="true" label="是" />
           </el-select>
         </el-form-item>
-        <el-form-item
-          label="父节点ID"
-          style="width:30%"
-        >
+        <el-form-item label="父节点ID" style="width: 30%">
           <el-cascader
             v-model="form.parentId"
-            style="width:100%"
+            style="width: 100%"
             :disabled="!isEdit"
             :options="menuOption"
-            :props="{ checkStrictly: true,label:'title',value:'ID',disabled:'disabled',emitPath:false}"
+            :props="{
+              checkStrictly: true,
+              label: 'title',
+              value: 'ID',
+              disabled: 'disabled',
+              emitPath: false,
+            }"
             :show-all-levels="false"
             filterable
           />
         </el-form-item>
-        <el-form-item
-          label="文件路径"
-          prop="component"
-          style="width:60%"
-        >
+        <el-form-item label="文件路径" prop="component" style="width: 60%">
           <el-input
             v-model="form.component"
             autocomplete="off"
             placeholder="页面:view/xxx/xx.vue 插件:plugin/xx/xx.vue"
             @blur="fmtComponent"
           />
-          <span style="font-size:12px;margin-right:12px;">如果菜单包含子菜单，请创建router-view二级路由页面或者</span><el-button
-            style="margin-top:4px"
+          <span style="font-size: 12px; margin-right: 12px"
+            >如果菜单包含子菜单，请创建router-view二级路由页面或者</span
+          ><el-button
+            style="margin-top: 4px"
             @click="form.component = 'view/routerHolder.vue'"
-          >点我设置</el-button>
+            >点我设置</el-button
+          >
         </el-form-item>
-        <el-form-item
-          label="展示名称"
-          prop="meta.title"
-          style="width:30%"
-        >
-          <el-input
-            v-model="form.meta.title"
-            autocomplete="off"
-          />
+        <el-form-item label="展示名称" prop="meta.title" style="width: 30%">
+          <el-input v-model="form.meta.title" autocomplete="off" />
         </el-form-item>
-        <el-form-item
-          label="图标"
-          prop="meta.icon"
-          style="width:30%"
-        >
-          <icon
-            :meta="form.meta"
-            style="width:100%"
-          />
+        <el-form-item label="图标" prop="meta.icon" style="width: 30%">
+          <icon :meta="form.meta" style="width: 100%" />
         </el-form-item>
-        <el-form-item
-          label="排序标记"
-          prop="sort"
-          style="width:30%"
-        >
-          <el-input
-            v-model.number="form.sort"
-            autocomplete="off"
-          />
+        <el-form-item label="排序标记" prop="sort" style="width: 30%">
+          <el-input v-model.number="form.sort" autocomplete="off" />
         </el-form-item>
-        <el-form-item
-          prop="meta.activeName"
-          style="width:30%"
-        >
+        <el-form-item prop="meta.activeName" style="width: 30%">
           <template #label>
             <div>
               <span> 高亮菜单 </span>
@@ -289,44 +230,28 @@
         <el-form-item
           label="KeepAlive"
           prop="meta.keepAlive"
-          style="width:30%"
+          style="width: 30%"
         >
           <el-select
             v-model="form.meta.keepAlive"
-            style="width:100%"
+            style="width: 100%"
             placeholder="是否keepAlive缓存页面"
           >
-            <el-option
-              :value="false"
-              label="否"
-            />
-            <el-option
-              :value="true"
-              label="是"
-            />
+            <el-option :value="false" label="否" />
+            <el-option :value="true" label="是" />
           </el-select>
         </el-form-item>
-        <el-form-item
-          label="CloseTab"
-          prop="meta.closeTab"
-          style="width:30%"
-        >
+        <el-form-item label="CloseTab" prop="meta.closeTab" style="width: 30%">
           <el-select
             v-model="form.meta.closeTab"
-            style="width:100%"
+            style="width: 100%"
             placeholder="是否自动关闭tab"
           >
-            <el-option
-              :value="false"
-              label="否"
-            />
-            <el-option
-              :value="true"
-              label="是"
-            />
+            <el-option :value="false" label="否" />
+            <el-option :value="true" label="是" />
           </el-select>
         </el-form-item>
-        <el-form-item style="width:30%">
+        <el-form-item style="width: 30%">
           <template #label>
             <div>
               <span> 是否为基础页面 </span>
@@ -342,36 +267,30 @@
 
           <el-select
             v-model="form.meta.defaultMenu"
-            style="width:100%"
+            style="width: 100%"
             placeholder="是否为基础页面"
           >
-            <el-option
-              :value="false"
-              label="否"
-            />
-            <el-option
-              :value="true"
-              label="是"
-            />
+            <el-option :value="false" label="否" />
+            <el-option :value="true" label="是" />
           </el-select>
         </el-form-item>
       </el-form>
       <div>
         <div class="flex items-center gap-2">
-          <el-button
-            type="primary"
-            icon="edit"
-            @click="addParameter(form)"
-          >新增菜单参数</el-button>
+          <el-button type="primary" icon="edit" @click="addParameter(form)"
+            >新增菜单参数</el-button
+          >
           <el-icon
             class="cursor-pointer"
-            @click="toDoc('https://www.bilibili.com/video/BV1kv4y1g7nT?p=9&vd_source=f2640257c21e3b547a790461ed94875e')"
-          ><VideoCameraFilled /></el-icon>
+            @click="
+              toDoc(
+                'https://www.bilibili.com/video/BV1kv4y1g7nT?p=9&vd_source=f2640257c21e3b547a790461ed94875e'
+              )
+            "
+            ><VideoCameraFilled
+          /></el-icon>
         </div>
-        <el-table
-          :data="form.parameters"
-          style="width: 100%;margin-top: 12px;"
-        >
+        <el-table :data="form.parameters" style="width: 100%; margin-top: 12px">
           <el-table-column
             align="left"
             prop="type"
@@ -379,40 +298,20 @@
             width="180"
           >
             <template #default="scope">
-              <el-select
-                v-model="scope.row.type"
-                placeholder="请选择"
-              >
-                <el-option
-                  key="query"
-                  value="query"
-                  label="query"
-                />
-                <el-option
-                  key="params"
-                  value="params"
-                  label="params"
-                />
+              <el-select v-model="scope.row.type" placeholder="请选择">
+                <el-option key="query" value="query" label="query" />
+                <el-option key="params" value="params" label="params" />
               </el-select>
             </template>
           </el-table-column>
-          <el-table-column
-            align="left"
-            prop="key"
-            label="参数key"
-            width="180"
-          >
+          <el-table-column align="left" prop="key" label="参数key" width="180">
             <template #default="scope">
               <div>
                 <el-input v-model="scope.row.key" />
               </div>
             </template>
           </el-table-column>
-          <el-table-column
-            align="left"
-            prop="value"
-            label="参数值"
-          >
+          <el-table-column align="left" prop="value" label="参数值">
             <template #default="scope">
               <div>
                 <el-input v-model="scope.row.value" />
@@ -424,36 +323,38 @@
               <div>
                 <el-button
                   type="danger"
-
                   icon="delete"
-                  @click="deleteParameter(form.parameters,scope.$index)"
-                >删除</el-button>
+                  @click="deleteParameter(form.parameters, scope.$index)"
+                  >删除</el-button
+                >
               </div>
             </template>
           </el-table-column>
         </el-table>
 
         <div class="flex items-center gap-2 mt-3">
-          <el-button
-            type="primary"
-            icon="edit"
-            @click="addBtn(form)"
-          >新增可控按钮
+          <el-button type="primary" icon="edit" @click="addBtn(form)"
+            >新增可控按钮
           </el-button>
           <el-icon
             class="cursor-pointer"
-            @click="toDoc('https://www.gin-vue-admin.com/guide/web/button-auth.html')"
-          ><QuestionFilled /></el-icon>
+            @click="
+              toDoc('https://www.gin-vue-admin.com/guide/web/button-auth.html')
+            "
+            ><QuestionFilled
+          /></el-icon>
           <el-icon
             class="cursor-pointer"
-            @click="toDoc('https://www.bilibili.com/video/BV1kv4y1g7nT?p=11&vd_source=f2640257c21e3b547a790461ed94875e')"
-          ><VideoCameraFilled /></el-icon>
+            @click="
+              toDoc(
+                'https://www.bilibili.com/video/BV1kv4y1g7nT?p=11&vd_source=f2640257c21e3b547a790461ed94875e'
+              )
+            "
+            ><VideoCameraFilled
+          /></el-icon>
         </div>
 
-        <el-table
-          :data="form.menuBtn"
-          style="width: 100%;margin-top: 12px;"
-        >
+        <el-table :data="form.menuBtn" style="width: 100%; margin-top: 12px">
           <el-table-column
             align="left"
             prop="name"
@@ -466,12 +367,7 @@
               </div>
             </template>
           </el-table-column>
-          <el-table-column
-            align="left"
-            prop="name"
-            label="备注"
-            width="180"
-          >
+          <el-table-column align="left" prop="name" label="备注" width="180">
             <template #default="scope">
               <div>
                 <el-input v-model="scope.row.desc" />
@@ -483,10 +379,10 @@
               <div>
                 <el-button
                   type="danger"
-
                   icon="delete"
-                  @click="deleteBtn(form.menuBtn,scope.$index)"
-                >删除</el-button>
+                  @click="deleteBtn(form.menuBtn, scope.$index)"
+                  >删除</el-button
+                >
               </div>
             </template>
           </el-table-column>
@@ -502,270 +398,271 @@ import {
   getMenuList,
   addBaseMenu,
   deleteBaseMenu,
-  getBaseMenuById
-} from '@/api/menu'
-import icon from '@/view/superAdmin/menu/icon.vue'
-import WarningBar from '@/components/warningBar/warningBar.vue'
-import { canRemoveAuthorityBtnApi } from '@/api/authorityBtn'
-import { reactive, ref } from 'vue'
-import { ElMessage, ElMessageBox } from 'element-plus'
-import { QuestionFilled, VideoCameraFilled } from '@element-plus/icons-vue'
+  getBaseMenuById,
+} from "@/api/menu";
+import icon from "@/view/superAdmin/menu/icon.vue";
+import WarningBar from "@/components/warningBar/warningBar.vue";
+import { canRemoveAuthorityBtnApi } from "@/api/authorityBtn";
+import { reactive, ref } from "vue";
+import { ElMessage, ElMessageBox } from "element-plus";
+import { QuestionFilled, VideoCameraFilled } from "@element-plus/icons-vue";
 
-import { toDoc } from '@/utils/doc'
+import { toDoc } from "@/utils/doc";
 
 defineOptions({
-  name: 'Menus',
-})
+  name: "Menus",
+});
 
 const rules = reactive({
-  path: [{ required: true, message: '请输入菜单name', trigger: 'blur' }],
-  component: [
-    { required: true, message: '请输入文件路径', trigger: 'blur' }
+  path: [{ required: true, message: "请输入菜单name", trigger: "blur" }],
+  component: [{ required: true, message: "请输入文件路径", trigger: "blur" }],
+  "meta.title": [
+    { required: true, message: "请输入菜单展示名称", trigger: "blur" },
   ],
-  'meta.title': [
-    { required: true, message: '请输入菜单展示名称', trigger: 'blur' }
-  ]
-})
+});
 
-const page = ref(1)
-const total = ref(0)
-const pageSize = ref(999)
-const tableData = ref([])
-const searchInfo = ref({})
+const page = ref(1);
+const total = ref(0);
+const pageSize = ref(999);
+const tableData = ref([]);
+const searchInfo = ref({});
 // 查询
-const getTableData = async() => {
-  const table = await getMenuList({ page: page.value, pageSize: pageSize.value, ...searchInfo.value })
+const getTableData = async () => {
+  const table = await getMenuList({
+    page: page.value,
+    pageSize: pageSize.value,
+    ...searchInfo.value,
+  });
   if (table.code === 0) {
-    tableData.value = table.data.list
-    total.value = table.data.total
-    page.value = table.data.page
-    pageSize.value = table.data.pageSize
+    tableData.value = table.data.list;
+    total.value = table.data.total;
+    page.value = table.data.page;
+    pageSize.value = table.data.pageSize;
   }
-}
+};
 
-getTableData()
+getTableData();
 
 // 新增参数
 const addParameter = (form) => {
   if (!form.parameters) {
-    form.parameters = []
+    form.parameters = [];
   }
   form.parameters.push({
-    type: 'query',
-    key: '',
-    value: ''
-  })
-}
+    type: "query",
+    key: "",
+    value: "",
+  });
+};
 
 const fmtComponent = () => {
-  form.value.component = form.value.component.replace(/\\/g, '/')
-}
+  form.value.component = form.value.component.replace(/\\/g, "/");
+};
 
 // 删除参数
 const deleteParameter = (parameters, index) => {
-  parameters.splice(index, 1)
-}
+  parameters.splice(index, 1);
+};
 
 // 新增可控按钮
 const addBtn = (form) => {
   if (!form.menuBtn) {
-    form.menuBtn = []
+    form.menuBtn = [];
   }
   form.menuBtn.push({
-    name: '',
-    desc: '',
-  })
-}
+    name: "",
+    desc: "",
+  });
+};
 // 删除可控按钮
-const deleteBtn = async(btns, index) => {
-  const btn = btns[index]
+const deleteBtn = async (btns, index) => {
+  const btn = btns[index];
   if (btn.ID === 0) {
-    btns.splice(index, 1)
-    return
+    btns.splice(index, 1);
+    return;
   }
-  const res = await canRemoveAuthorityBtnApi({ id: btn.ID })
+  const res = await canRemoveAuthorityBtnApi({ id: btn.ID });
   if (res.code === 0) {
-    btns.splice(index, 1)
+    btns.splice(index, 1);
   }
-}
+};
 
 const form = ref({
   ID: 0,
-  path: '',
-  name: '',
+  path: "",
+  name: "",
   hidden: false,
-  parentId: '',
-  component: '',
+  parentId: 0,
+  component: "",
   meta: {
-    activeName: '',
-    title: '',
-    icon: '',
+    activeName: "",
+    title: "",
+    icon: "",
     defaultMenu: false,
     closeTab: false,
-    keepAlive: false
+    keepAlive: false,
   },
   parameters: [],
-  menuBtn: []
-})
+  menuBtn: [],
+});
 const changeName = () => {
-  form.value.path = form.value.name
-}
+  form.value.path = form.value.name;
+};
 
 const handleClose = (done) => {
-  initForm()
-  done()
-}
+  initForm();
+  done();
+};
 // 删除菜单
 const deleteMenu = (ID) => {
-  ElMessageBox.confirm('此操作将永久删除所有角色下该菜单, 是否继续?', '提示', {
-    confirmButtonText: '确定',
-    cancelButtonText: '取消',
-    type: 'warning'
+  ElMessageBox.confirm("此操作将永久删除所有角色下该菜单, 是否继续?", "提示", {
+    confirmButtonText: "确定",
+    cancelButtonText: "取消",
+    type: "warning",
   })
-    .then(async() => {
-      const res = await deleteBaseMenu({ ID })
+    .then(async () => {
+      const res = await deleteBaseMenu({ ID });
       if (res.code === 0) {
         ElMessage({
-          type: 'success',
-          message: '删除成功!'
-        })
+          type: "success",
+          message: "删除成功!",
+        });
         if (tableData.value.length === 1 && page.value > 1) {
-          page.value--
+          page.value--;
         }
-        getTableData()
+        getTableData();
       }
     })
     .catch(() => {
       ElMessage({
-        type: 'info',
-        message: '已取消删除'
-      })
-    })
-}
+        type: "info",
+        message: "已取消删除",
+      });
+    });
+};
 // 初始化弹窗内表格方法
-const menuForm = ref(null)
-const checkFlag = ref(false)
+const menuForm = ref(null);
+const checkFlag = ref(false);
 const initForm = () => {
-  checkFlag.value = false
-  menuForm.value.resetFields()
+  checkFlag.value = false;
+  menuForm.value.resetFields();
   form.value = {
     ID: 0,
-    path: '',
-    name: '',
+    path: "",
+    name: "",
     hidden: false,
-    parentId: '',
-    component: '',
+    parentId: 0,
+    component: "",
     meta: {
-      title: '',
-      icon: '',
+      title: "",
+      icon: "",
       defaultMenu: false,
       closeTab: false,
-      keepAlive: false
-    }
-  }
-}
+      keepAlive: false,
+    },
+  };
+};
 // 关闭弹窗
 
-const dialogFormVisible = ref(false)
+const dialogFormVisible = ref(false);
 const closeDialog = () => {
-  initForm()
-  dialogFormVisible.value = false
-}
+  initForm();
+  dialogFormVisible.value = false;
+};
 // 添加menu
-const enterDialog = async() => {
-  menuForm.value.validate(async valid => {
+const enterDialog = async () => {
+  menuForm.value.validate(async (valid) => {
     if (valid) {
-      let res
+      let res;
       if (isEdit.value) {
-        res = await updateBaseMenu(form.value)
+        res = await updateBaseMenu(form.value);
       } else {
-        res = await addBaseMenu(form.value)
+        res = await addBaseMenu(form.value);
       }
       if (res.code === 0) {
         ElMessage({
-          type: 'success',
-          message: isEdit.value ? '编辑成功' : '添加成功!'
-        })
-        getTableData()
+          type: "success",
+          message: isEdit.value ? "编辑成功" : "添加成功!",
+        });
+        getTableData();
       }
-      initForm()
-      dialogFormVisible.value = false
+      initForm();
+      dialogFormVisible.value = false;
     }
-  })
-}
+  });
+};
 
 const menuOption = ref([
   {
-    ID: '0',
-    title: '根菜单'
-  }
-])
+    ID: "0",
+    title: "根菜单",
+  },
+]);
 const setOptions = () => {
   menuOption.value = [
     {
-      ID: '0',
-      title: '根目录'
-    }
-  ]
-  setMenuOptions(tableData.value, menuOption.value, false)
-}
+      ID: 0,
+      title: "根目录",
+    },
+  ];
+  setMenuOptions(tableData.value, menuOption.value, false);
+};
 const setMenuOptions = (menuData, optionsData, disabled) => {
   menuData &&
-        menuData.forEach(item => {
-          if (item.children && item.children.length) {
-            const option = {
-              title: item.meta.title,
-              ID: String(item.ID),
-              disabled: disabled || item.ID === form.value.ID,
-              children: []
-            }
-            setMenuOptions(
-              item.children,
-              option.children,
-              disabled || item.ID === form.value.ID
-            )
-            optionsData.push(option)
-          } else {
-            const option = {
-              title: item.meta.title,
-              ID: String(item.ID),
-              disabled: disabled || item.ID === form.value.ID
-            }
-            optionsData.push(option)
-          }
-        })
-}
+    menuData.forEach((item) => {
+      if (item.children && item.children.length) {
+        const option = {
+          title: item.meta.title,
+          ID: item.ID,
+          disabled: disabled || item.ID === form.value.ID,
+          children: [],
+        };
+        setMenuOptions(
+          item.children,
+          option.children,
+          disabled || item.ID === form.value.ID
+        );
+        optionsData.push(option);
+      } else {
+        const option = {
+          title: item.meta.title,
+          ID: item.ID,
+          disabled: disabled || item.ID === form.value.ID,
+        };
+        optionsData.push(option);
+      }
+    });
+};
 
 // 添加菜单方法，id为 0则为添加根菜单
-const isEdit = ref(false)
-const dialogTitle = ref('新增菜单')
+const isEdit = ref(false);
+const dialogTitle = ref("新增菜单");
 const addMenu = (id) => {
-  dialogTitle.value = '新增菜单'
-  form.value.parentId = String(id)
-  isEdit.value = false
-  setOptions()
-  dialogFormVisible.value = true
-}
+  dialogTitle.value = "新增菜单";
+  form.value.parentId = id;
+  isEdit.value = false;
+  setOptions();
+  dialogFormVisible.value = true;
+};
 // 修改菜单方法
-const editMenu = async(id) => {
-  dialogTitle.value = '编辑菜单'
-  const res = await getBaseMenuById({ id })
-  form.value = res.data.menu
-  isEdit.value = true
-  setOptions()
-  dialogFormVisible.value = true
-}
-
+const editMenu = async (id) => {
+  dialogTitle.value = "编辑菜单";
+  const res = await getBaseMenuById({ id });
+  form.value = res.data.menu;
+  isEdit.value = true;
+  setOptions();
+  dialogFormVisible.value = true;
+};
 </script>
 
 <style scoped lang="scss">
 .warning {
   color: #dc143c;
 }
-.icon-column{
+.icon-column {
   display: flex;
   align-items: center;
-  .el-icon{
+  .el-icon {
     margin-right: 8px;
   }
 }


### PR DESCRIPTION
解决 #1700 

将ParentId 声明由 string 改成是 uint
理由：
1. 数据库的类似是bigint但代码中是string， 数据库可能运行但不能走索引（如果有）
2. 在代码中map使用uint做key更省内存和更快，可参考 https://stackoverflow.com/questions/72237864/string-vs-integer-as-map-key-for-memory-utilization-in-golang

缺点：
1. 不能向前兼容
2. 涉及修改文件多