### PR TITLE
sys_base_menu.go: fix table name "sys_base_menus" specified more than…

### DIFF
--- a/server/service/system/sys_base_menu.go
+++ b/server/service/system/sys_base_menu.go
@@ -21,22 +21,33 @@ var BaseMenuServiceApp = new(BaseMenuService)
 func (baseMenuService *BaseMenuService) DeleteBaseMenu(id int) (err error) {
 	err = global.GVA_DB.Preload("MenuBtn").Preload("Parameters").Where("parent_id = ?", id).First(&system.SysBaseMenu{}).Error
 	if err != nil {
-		var menu system.SysBaseMenu
-		db := global.GVA_DB.Preload("SysAuthoritys").Where("id = ?", id).First(&menu).Delete(&menu)
-		err = global.GVA_DB.Delete(&system.SysBaseMenuParameter{}, "sys_base_menu_id = ?", id).Error
-		err = global.GVA_DB.Delete(&system.SysBaseMenuBtn{}, "sys_base_menu_id = ?", id).Error
-		err = global.GVA_DB.Delete(&system.SysAuthorityBtn{}, "sys_menu_id = ?", id).Error
-		if err != nil {
-			return err
-		}
-		if len(menu.SysAuthoritys) > 0 {
-			err = global.GVA_DB.Model(&menu).Association("SysAuthoritys").Delete(&menu.SysAuthoritys)
-		} else {
-			err = db.Error
+		global.GVA_DB.Transaction(func(tx *gorm.DB) error {
+			var menu system.SysBaseMenu
+			err = global.GVA_DB.Preload("SysAuthoritys").Where("id = ?", id).First(&menu).Error
 			if err != nil {
-				return
+				return err
 			}
-		}
+			global.GVA_DB.Delete((&menu))
+			err = global.GVA_DB.Delete(&system.SysBaseMenuParameter{}, "sys_base_menu_id = ?", id).Error
+			if err != nil {
+				return err
+			}
+			err = global.GVA_DB.Delete(&system.SysBaseMenuBtn{}, "sys_base_menu_id = ?", id).Error
+			if err != nil {
+				return err
+			}
+			err = global.GVA_DB.Delete(&system.SysAuthorityBtn{}, "sys_menu_id = ?", id).Error
+			if err != nil {
+				return err
+			}
+			if len(menu.SysAuthoritys) > 0 {
+				err = global.GVA_DB.Model(&menu).Association("SysAuthoritys").Delete(&menu.SysAuthoritys)
+			}
+			if err != nil {
+				return err
+			}
+			return nil
+		})
 	} else {
 		return errors.New("此菜单存在子菜单不可删除")
 	}


### PR DESCRIPTION
修改了在PG下删除菜单报错：

/server/service/system/sys_base_menu.go:25 ERROR: table name "sys_base_menus" specified more than once (SQLSTATE 42712)
[0.944ms] [rows:1] UPDATE "sys_base_menus" SET "deleted_at"='2024-04-11 16:04:03.209' FROM "sys_base_menus" WHERE id = 22 AND "sys_base_menus"."deleted_at" IS NULL AND "sys_base_menus"."id" = 22


将Proload和Delete分开，并加入了事务