### PR TITLE
verify.go: fix ParentId can't pass notempty verify

### DIFF
--- a/server/utils/verify.go
+++ b/server/utils/verify.go
@@ -3,7 +3,7 @@ package utils
 var (
 	IdVerify               = Rules{"ID": []string{NotEmpty()}}
 	ApiVerify              = Rules{"Path": {NotEmpty()}, "Description": {NotEmpty()}, "ApiGroup": {NotEmpty()}, "Method": {NotEmpty()}}
-	MenuVerify             = Rules{"Path": {NotEmpty()}, "ParentId": {NotEmpty()}, "Name": {NotEmpty()}, "Component": {NotEmpty()}, "Sort": {Ge("0")}}
+	MenuVerify             = Rules{"Path": {NotEmpty()}, "ParentId": {Ge("0")}, "Name": {NotEmpty()}, "Component": {NotEmpty()}, "Sort": {Ge("0")}}
 	MenuMetaVerify         = Rules{"Title": {NotEmpty()}}
 	LoginVerify            = Rules{"CaptchaId": {NotEmpty()}, "Username": {NotEmpty()}, "Password": {NotEmpty()}}
 	RegisterVerify         = Rules{"Username": {NotEmpty()}, "NickName": {NotEmpty()}, "Password": {NotEmpty()}, "AuthorityId": {NotEmpty()}}


### PR DESCRIPTION
通过修改ParentId的校验规则 NotEmpty -> Ge(0)