### PR TITLE
点击跳转代码插件修复websotrm bug

### DIFF
--- a/web/vitePlugin/codeServer/index.js
+++ b/web/vitePlugin/codeServer/index.js
@@ -11,8 +11,9 @@ export default function GvaPositionServer() {
             req._parsedUrl.query && req._parsedUrl.query.split('=')[1]
           if (path && path !== 'null') {
             if (process.env.VITE_EDITOR === 'webstorm') {
-              const linePath = path.split(':')[1]
-              const filePath = path.split(':')[0]
+              const lastColonIndex = path.lastIndexOf(':')
+              const linePath = path.substring(lastColonIndex + 1)
+              const filePath = path.substring(0, lastColonIndex)
               const platform = os()
               if (platform === 'win32') {
                 child_process.exec(


### PR DESCRIPTION
不支持路径有中文!!!!
目前在前端使用按键为 shift+alt +点击鼠标左键

说明: 只在开发环境中有用  需要将/web/.env.development中的VITE_POSITION改为open 
VITE_EDITOR设置为vscode或者websotrm即可开启使用, 