### PR TITLE
fixed: 修复文件分片上传在已选择文件的情况下，再次选择并取消出现控制台飘红且原文件清空的bug

### DIFF
--- a/web/src/view/example/breakpoint/breakpoint.vue
+++ b/web/src/view/example/breakpoint/breakpoint.vue
@@ -83,6 +83,11 @@ const percentageFlage = ref(true)
 
 // 选中文件的函数
 const choseFile = async(e) => {
+
+  // 点击选择文件后取消 直接return
+  if (!e.target.files.length) {
+    return
+  }
   const fileR = new FileReader() // 创建一个reader用来读取文件流
   const fileInput = e.target.files[0] // 获取当前文件
   const maxSize = 5 * 1024 * 1024


### PR DESCRIPTION
复现步骤：
1.先选择一个文件
<img width="1155" alt="image" src="https://github.com/flipped-aurora/gin-vue-admin/assets/44397702/a07fdd77-e331-44c3-af8b-3ae13046e11d">

2.再次点击选择文件，点击取消  
<img width="755" alt="image" src="https://github.com/flipped-aurora/gin-vue-admin/assets/44397702/e97d5301-7857-4498-987d-630344ff82a0">
3.控制台飘红且原文件被删除  
![image](https://github.com/flipped-aurora/gin-vue-admin/assets/44397702/8a338d1b-84ed-4757-ad2a-a0a1f918e753)
<img width="1058" alt="image" src="https://github.com/flipped-aurora/gin-vue-admin/assets/44397702/d7a5a51a-4c57-4376-a0cf-17a12667d5cd">

