### PR TITLE
添加展示多硬盘用量信息的功能

### DIFF
--- a/server/config.yaml
+++ b/server/config.yaml
@@ -233,6 +233,10 @@ hua-wei-obs:
 excel:
   dir: ./resource/excel/
 
+# disk usage configuration
+disk-list:
+  - mount-point: "/"
+
 # 跨域配置
 # 需要配合 server/initialize/router.go -> `Router.Use(middleware.CorsByRules())` 使用
 cors:

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -27,6 +27,8 @@ type Server struct {
 
 	Excel Excel `mapstructure:"excel" json:"excel" yaml:"excel"`
 
+	DiskList []DiskList `mapstructure:"disk-list" json:"disk-list" yaml:"disk-list"`
+
 	// 跨域配置
 	Cors CORS `mapstructure:"cors" json:"cors" yaml:"cors"`
 }

--- a/server/config/disk.go
+++ b/server/config/disk.go
@@ -1,0 +1,9 @@
+package config
+
+type Disk struct {
+	MountPoint string `mapstructure:"mount-point" json:"mount-point" yaml:"mount-point"`
+}
+
+type DiskList struct {
+	Disk `yaml:",inline" mapstructure:",squash"`
+}

--- a/server/utils/server.go
+++ b/server/utils/server.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"runtime"
 	"time"
 

--- a/server/utils/server.go
+++ b/server/utils/server.go
@@ -20,7 +20,7 @@ type Server struct {
 	Os   Os   `json:"os"`
 	Cpu  Cpu  `json:"cpu"`
 	Ram  Ram  `json:"ram"`
-	Disk Disk `json:"disk"`
+	Disk []Disk `json:"disk"`
 }
 
 type Os struct {
@@ -43,6 +43,7 @@ type Ram struct {
 }
 
 type Disk struct {
+	MountPoint  string `json:"mountPoint"`
 	UsedMB      int `json:"usedMb"`
 	UsedGB      int `json:"usedGb"`
 	TotalMB     int `json:"totalMb"`
@@ -104,15 +105,21 @@ func InitRAM() (r Ram, err error) {
 //@description: 硬盘信息
 //@return: d Disk, err error
 
-func InitDisk() (d Disk, err error) {
-	if u, err := disk.Usage("/"); err != nil {
-		return d, err
-	} else {
-		d.UsedMB = int(u.Used) / MB
-		d.UsedGB = int(u.Used) / GB
-		d.TotalMB = int(u.Total) / MB
-		d.TotalGB = int(u.Total) / GB
-		d.UsedPercent = int(u.UsedPercent)
+func InitDisk() (d []Disk, err error) {
+	for i := range global.GVA_CONFIG.DiskList {
+		mp := global.GVA_CONFIG.DiskList[i].MountPoint
+		if u, err := disk.Usage(mp); err != nil {
+			return d, err
+		} else {
+			d = append(d, Disk{
+				MountPoint:  mp,
+				UsedMB:      int(u.Used) / MB,
+				UsedGB:      int(u.Used) / GB,
+				TotalMB:     int(u.Total) / MB,
+				TotalGB:     int(u.Total) / GB,
+				UsedPercent: int(u.UsedPercent),
+			})
+		}
 	}
 	return d, nil
 }

--- a/web/src/view/system/state.vue
+++ b/web/src/view/system/state.vue
@@ -60,42 +60,55 @@
             <div>Disk</div>
           </template>
           <div>
-            <el-row :gutter="10">
+            <el-row
+                v-for="(item, index) in state.disk"
+                :key="index"
+                :gutter="10"
+                style="margin-bottom: 2rem"
+            >
               <el-col :span="12">
+
+                <el-row :gutter="10">
+                  <el-col :span="12">MountPoint</el-col>
+                  <el-col
+                      :span="12"
+                      v-text="item.mountPoint"
+                  />
+                </el-row>
                 <el-row :gutter="10">
                   <el-col :span="12">total (MB)</el-col>
                   <el-col
-                    :span="12"
-                    v-text="state.disk.totalMb"
+                      :span="12"
+                      v-text="item.totalMb"
                   />
                 </el-row>
                 <el-row :gutter="10">
                   <el-col :span="12">used (MB)</el-col>
                   <el-col
-                    :span="12"
-                    v-text="state.disk.usedMb"
+                      :span="12"
+                      v-text="item.usedMb"
                   />
                 </el-row>
                 <el-row :gutter="10">
                   <el-col :span="12">total (GB)</el-col>
                   <el-col
-                    :span="12"
-                    v-text="state.disk.totalGb"
+                      :span="12"
+                      v-text="item.totalGb"
                   />
                 </el-row>
                 <el-row :gutter="10">
                   <el-col :span="12">used (GB)</el-col>
                   <el-col
-                    :span="12"
-                    v-text="state.disk.usedGb"
+                      :span="12"
+                      v-text="item.usedGb"
                   />
                 </el-row>
               </el-col>
               <el-col :span="12">
                 <el-progress
-                  type="dashboard"
-                  :percentage="state.disk.usedPercent"
-                  :color="colors"
+                    type="dashboard"
+                    :percentage="item.usedPercent"
+                    :color="colors"
                 />
               </el-col>
             </el-row>


### PR DESCRIPTION
## config.yaml

默认为`/`，支持配置多路径，如下

Windows:

```
disk-list:
  - mount-point: "C:"
  - mount-point: "D:"
  - mount-point: "E:"
```

Linux:

```
disk-list:
  - mount-point: "/"
  - mount-point: "/mnt/disk1"
  - mount-point: "/mnt/disk2"
```

![image](https://github.com/flipped-aurora/gin-vue-admin/assets/63502979/3cd8cb30-acc3-4845-a4cc-265a5b2b0599)
