### PR TITLE
优化如果join表时出现重复的字段或者需要有函数时可以导出别名的值

### DIFF
--- a/server/service/system/sys_export_template.go
+++ b/server/service/system/sys_export_template.go
@@ -223,9 +223,14 @@ func (sysExportTemplateService *SysExportTemplateService) ExportExcel(templateID
 		var row []string
 		for _, column := range columns {
 			if len(template.JoinTemplate) > 0 {
-				columnArr := strings.Split(column, ".")
-				if len(columnArr) > 1 {
-					column = strings.Split(column, ".")[1]
+				columnAs := strings.Split(column, " as ")
+				if len(columnAs) > 1 {
+					column = strings.TrimSpace(strings.Split(column, " as ")[1])
+				} else {
+					columnArr := strings.Split(column, ".")
+					if len(columnArr) > 1 {
+						column = strings.Split(column, ".")[1]
+					}
 				}
 			}
 			row = append(row, fmt.Sprintf("%v", table[column]))

--- a/web/src/view/systemTools/exportTemplate/exportTemplate.vue
+++ b/web/src/view/systemTools/exportTemplate/exportTemplate.vue
@@ -431,6 +431,7 @@ const templatePlaceholder = `模板信息格式：key标识数据库column列名
   "table_column4":"第四列",
 }
 如果增加了JOINS导出key应该列为 {table_name1.table_column1:"第一列",table_name2.table_column2:"第二列"}
+如果有重复的列名导出格式应为 {table_name1.table_column1 as key:"第一列",table_name2.table_column2 as key2:"第二列"}
 JOINS模式下不支持导入
 `
 


### PR DESCRIPTION
如果join时有两个表出现一样的字段就会造成其中一个字段显示为空，所以加了一个 as  给字段器一个别名优化完代码提交