### PR TITLE
Fixed system.vue: 日志留存时间json key错误

### DIFF
--- a/web/src/view/systemTools/system/system.vue
+++ b/web/src/view/systemTools/system/system.vue
@@ -96,7 +96,7 @@
             <el-input v-model="config.zap['stacktrace-key']" />
           </el-form-item>
           <el-form-item label="日志留存时间(默认以天为单位)">
-            <el-input v-model.number="config.zap['max-age']" />
+            <el-input v-model.number="config.zap['retention-day']" />
           </el-form-item>
           <el-form-item label="显示行">
             <el-checkbox v-model="config.zap['show-line']" />


### PR DESCRIPTION
后端对应的json key是retention-day

![image](https://github.com/flipped-aurora/gin-vue-admin/assets/63502979/9b132173-81e8-4922-86b4-fd65f1c89f4d)
