### PR TITLE
业务路由的代码错误

### DIFF
--- a/server/initialize/router_biz.go
+++ b/server/initialize/router_biz.go
@@ -12,8 +12,8 @@ func holder(routers ...*gin.RouterGroup) {
 }
 
 func initBizRouter(routers ...*gin.RouterGroup) {
-	publicGroup := routers[0]
-	privateGroup := routers[1]
+	privateGroup := routers[0]
+	publicGroup := routers[1]
 
 	holder(publicGroup, privateGroup)
 }


### PR DESCRIPTION
Update router_biz.go

```
// 注册业务路由
initBizRouter(PrivateGroup, PublicGroup)
```

privateGroup是切片的第一个。publicGroup是切片的第一个。
现在的代码搞反了