### PR TITLE
获取服务器信息和配置文件内容，不写入操作日志

### DIFF
--- a/server/router/system/sys_system.go
+++ b/server/router/system/sys_system.go
@@ -10,11 +10,15 @@ type SysRouter struct{}
 
 func (s *SysRouter) InitSystemRouter(Router *gin.RouterGroup) {
 	sysRouter := Router.Group("system").Use(middleware.OperationRecord())
+	sysRouterWithoutRecord := Router.Group("system")
+
 	systemApi := v1.ApiGroupApp.SystemApiGroup.SystemApi
 	{
-		sysRouter.POST("getSystemConfig", systemApi.GetSystemConfig) // 获取配置文件内容
 		sysRouter.POST("setSystemConfig", systemApi.SetSystemConfig) // 设置配置文件内容
-		sysRouter.POST("getServerInfo", systemApi.GetServerInfo)     // 获取服务器信息
 		sysRouter.POST("reloadSystem", systemApi.ReloadSystem)       // 重启服务
+	}
+	{
+		sysRouterWithoutRecord.POST("getSystemConfig", systemApi.GetSystemConfig) // 获取配置文件内容
+		sysRouterWithoutRecord.POST("getServerInfo", systemApi.GetServerInfo)     // 获取服务器信息
 	}
 }


### PR DESCRIPTION
获取服务器状态的页面 前端会周期性请求接口，没必要写入操作日志。