### PR TITLE
Dockerfile修复工作路径的问题

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,12 +16,16 @@ LABEL MAINTAINER="SliverHorn@sliver_horn@qq.com"
 # 设置时区
 ENV TZ=Asia/Shanghai
 RUN apk update && apk add --no-cache tzdata openntpd \
-    && ln -sf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
+    && ln -sf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 WORKDIR /go/src/github.com/flipped-aurora/gin-vue-admin/server
 
 COPY --from=0 /go/src/github.com/flipped-aurora/gin-vue-admin/server/server ./
 COPY --from=0 /go/src/github.com/flipped-aurora/gin-vue-admin/server/resource ./resource/
 COPY --from=0 /go/src/github.com/flipped-aurora/gin-vue-admin/server/config.docker.yaml ./
+
+# 挂载目录：如果使用了sqlite数据库，容器命令示例：docker run -d -v /宿主机路径/gva.db:/go/src/github.com/flipped-aurora/gin-vue-admin/server/gva.db -p 8888:8888 --name gva-server-v1 gva-server:1.0
+# VOLUME ["/go/src/github.com/flipped-aurora/gin-vue-admin/server"]
 
 EXPOSE 8888
 ENTRYPOINT ./server -c config.docker.yaml


### PR DESCRIPTION
在之前的版本中，存在一个工作路径切换的问题，这导致文件被错误地复制到根路径，而不是保持在预期的工作目录中。
为了支持使用sqlite数据库，添加了挂载目录的命令示例（默认注释掉）。