### PR TITLE
column参数类型是number

### DIFF
--- a/server/resource/package/web/view/table.vue.tpl
+++ b/server/resource/package/web/view/table.vue.tpl
@@ -357,7 +357,7 @@
     </el-drawer>
 
     <el-drawer destroy-on-close size="800" v-model="detailShow" :show-close="true" :before-close="closeDetailShow">
-            <el-descriptions column="1" border>
+            <el-descriptions :column="1" border>
             {{- range .Fields}}
               {{- if .Desc }}
                     <el-descriptions-item label="{{ .FieldDesc }}">


### PR DESCRIPTION
避免浏览器console的warn提示
Vue warn]: Invalid prop: type check failed for prop "column". Expected Number with value 1, got String with value "1".