### PR TITLE
修改模板，去除 `生成代码` model 行尾空格

### DIFF
--- a/server/resource/plugin/server/model/model.go.template
+++ b/server/resource/plugin/server/model/model.go.template
@@ -38,7 +38,7 @@ type {{.StructName}} struct {
     {{.FieldName}}  *{{.FieldType}} `json:"{{.FieldJson}}" form:"{{.FieldJson}}" gorm:"{{- if ne .FieldIndexType "" -}}{{ .FieldIndexType }};{{- end -}}{{- if .PrimaryKey -}}primarykey;{{- end -}}{{- if .DefaultValue -}}default:{{ .DefaultValue }};{{- end -}}column:{{.ColumnName}};comment:{{.Comment}};{{- if .DataTypeLong -}}size:{{.DataTypeLong}};{{- end -}}" {{- if .Require }} binding:"required"{{- end -}}`
     {{- else }}
     {{.FieldName}}  {{.FieldType}} `json:"{{.FieldJson}}" form:"{{.FieldJson}}" gorm:"{{- if ne .FieldIndexType "" -}}{{ .FieldIndexType }};{{- end -}}{{- if .PrimaryKey -}}primarykey;{{- end -}}{{- if .DefaultValue -}}default:{{ .DefaultValue }};{{- end -}}column:{{.ColumnName}};comment:{{.Comment}};{{- if .DataTypeLong -}}size:{{.DataTypeLong}};{{- end -}}" {{- if .Require }} binding:"required"{{- end -}}`
-    {{- end }}  {{ if .FieldDesc }}//{{.FieldDesc}} {{ end }}
+    {{- end }}  {{ if .FieldDesc }}//{{.FieldDesc}}{{ end }}
 {{- end }}
     {{- if .AutoCreateResource }}
     CreatedBy  uint   `gorm:"column:created_by;comment:创建者"`


### PR DESCRIPTION
修改前
![image](https://github.com/user-attachments/assets/4f3ddf50-5646-45c4-8f79-6f8e99c85074)

修改后
![image](https://github.com/user-attachments/assets/406fcba5-cd2c-4332-a05e-a3eb2e4ece81)

行尾不会再有空格