### PR TITLE
hotfix:项目初始化时如果选MSSQL，则会因为重复项目插入报错。另外修复了角色菜单权限表中9528和8881两个角色弄反了的错误。

### DIFF
--- a/server/source/system/authorities_menus.go
+++ b/server/source/system/authorities_menus.go
@@ -50,17 +50,18 @@ func (i *initMenuAuthority) InitializeData(ctx context.Context) (next context.Co
 	}
 
 	// 8881
-	menu8881 := menus[:2]
+	menu8881 := make([]sysModel.SysBaseMenu, 4)
+	copy(menu8881, menus[:2])
 	menu8881 = append(menu8881, menus[7])
-	if err = db.Model(&authorities[1]).Association("SysBaseMenus").Replace(menu8881); err != nil {
+	if err = db.Model(&authorities[2]).Association("SysBaseMenus").Replace(menu8881); err != nil {
 		return next, err
 	}
 
 	// 9528
-	if err = db.Model(&authorities[2]).Association("SysBaseMenus").Replace(menus[:11]); err != nil {
+	if err = db.Model(&authorities[1]).Association("SysBaseMenus").Replace(menus[:11]); err != nil {
 		return next, err
 	}
-	if err = db.Model(&authorities[2]).Association("SysBaseMenus").Append(menus[12:17]); err != nil {
+	if err = db.Model(&authorities[1]).Association("SysBaseMenus").Append(menus[12:17]); err != nil {
 		return next, err
 	}
 	return next, nil


### PR DESCRIPTION
项目初始化时如果选MSSQL，则会因为重复项目插入报错。
另外修复了角色菜单权限表中9528和8881两个角色弄反了的错误。