### PR TITLE
Update basetypes.go, fixed origin_setting column read error

### DIFF
--- a/server/model/common/basetypes.go
+++ b/server/model/common/basetypes.go
@@ -23,11 +23,11 @@ func (m *JSONMap) Scan(value interface{}) error {
 		*m = make(map[string]interface{})
 		return nil
 	}
-	bytes, ok := value.([]byte)
+	text, ok := value.(string)
 	if !ok {
-		return errors.New("Scan source was not []bytes")
+		return errors.New("Scan source was not text")
 	}
-	err := json.Unmarshal(bytes, m)
+	err := json.Unmarshal([]byte(text), m)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
新初始化数据库，修改前端配置后，把origin_setting当作[]byte去读取会报错：
```json
{"error": "sql: Scan error on column index 13, name \"origin_setting\": Scan source was not []bytes"}
```
如果数据库不支持json的话一般是当作text来存的吧，所以应该可以直接改成当string去读取（我只在pgsql下进行了测试）