### PR TITLE
feat: edit global.js support plugin svg

### DIFF
--- a/web/src/core/global.js
+++ b/web/src/core/global.js
@@ -16,20 +16,28 @@ const createIconComponent = (name) => ({
 })
 
 const registerIcons = async(app) => {
-  const iconModules = import.meta.glob('@/assets/icons/**/*.svg')
-  for (const path in iconModules) {
+  const iconModules = import.meta.glob('@/assets/icons/**/*.svg') // 系统目录 svg 图标
+  const pluginIconModules = import.meta.glob('@/plugin/**/assets/icons/**/*.svg') // 插件目录 svg 图标
+  const mergedIconModules = Object.assign({}, iconModules, pluginIconModules); // 合并所有 svg 图标
+  for (const path in mergedIconModules) {
+    let pluginName = ""
+    if (path.startsWith("/src/plugin/")) {
+      pluginName = `${path.split('/')[3]}-`
+    }
     const iconName = path.split('/').pop().replace(/\.svg$/, '')
     // 如果iconName带空格则不加入到图标库中并且提示名称不合法
     if (iconName.indexOf(' ') !== -1) {
-      console.error(`icon ${iconName}.svg includes whitespace`)
+      console.error(`icon ${iconName}.svg includes whitespace in ${path}`)
       continue
     }
+    const key = `${pluginName}${iconName}`
+    console.log(key)
     const iconComponent = createIconComponent(iconName)
     config.logs.push({
-      'key': iconName,
+      'key': key,
       'label': iconName,
     })
-    app.component(iconName, iconComponent)
+    app.component(key, iconComponent)
   }
 }
 

--- a/web/src/core/global.js
+++ b/web/src/core/global.js
@@ -31,7 +31,6 @@ const registerIcons = async(app) => {
       continue
     }
     const key = `${pluginName}${iconName}`
-    console.log(key)
     const iconComponent = createIconComponent(iconName)
     config.logs.push({
       'key': key,


### PR DESCRIPTION
- 支持插件资源图标
- 增强插件资源分离(插件的assets 资源放在插件目录(web)下即可)
- 可能还能帮助减少插件使用部署步骤(不用再拷贝到 assets 下了)，同时不影响老的部署使用方式(插件图标有插件名作为前缀)