### PR TITLE
fix: support pluginPath svg file as component show list when dev mode

### DIFF
--- a/web/src/core/global.js
+++ b/web/src/core/global.js
@@ -31,10 +31,12 @@ const registerIcons = async(app) => {
       continue
     }
     const key = `${pluginName}${iconName}`
-    const iconComponent = createIconComponent(iconName)
+    // 开发模式下列出所有 svg 图标，方便开发者直接查找复制使用
+    import.meta.env.MODE == 'development' && console.log(`svg-icon-component: <${key} />`)
+    const iconComponent = createIconComponent(key)
     config.logs.push({
       'key': key,
-      'label': iconName,
+      'label': key,
     })
     app.component(key, iconComponent)
   }

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -94,6 +94,7 @@ export default ({
       }),
       vuePlugin(),
       svgBuilder('./src/assets/icons/'),
+      svgBuilder('./src/plugin/'),
       [Banner(`\n Build based on gin-vue-admin \n Time : ${timestamp}`)],
       VueFilePathPlugin("./src/pathInfo.json")
     ],


### PR DESCRIPTION
修复插件目录下 svg 文件像 项目目录下的 svg 一样直接作为组件使用
> 插件目录下的 svg 文件会自动带插件名(目录名)前缀(防止不同插件目录下同 svg 文件名冲突问题)。

具体使用方法如下：

1. 在插件目录中任意目录结构下 存放 svg 文件。参考如下目录结构：
```bash
$ pwd
~/Projects/gin-vue-admin/web/src/plugin
$ tree email
email
├── api
│   └── email.js
├── assets
│   └── icons
│       └── ali
│           ├── c-coin-fill.svg
│           └── c-dataserver.svg
└── view
    └── index.vue
```

2. 在开发模式下，浏览器 DevTool 控制台 console 中会列举出 所有扫描到可使用的 svg 组件使用代码。
![image](https://github.com/user-attachments/assets/ba120798-c96f-4f56-a313-5e367bef24f8)


3. 将 svg 组件代码复制后，直接在需要的地方即可在对应页面看到图表显示。如下代码所示：
> 一般推荐插件的 svg 仅在该插件内使用，以保持良好的代码和资源组织方式
```diff
diff --git a/web/src/plugin/email/view/index.vue b/web/src/plugin/email/view/index.vue
index 11d57e44..4b25ab58 100644
--- a/web/src/plugin/email/view/index.vue
+++ b/web/src/plugin/email/view/index.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
     <warning-bar title="需要提前配置email配置文件，为防止不必要的垃圾邮件，在线体验功能不开放此功能体验。" />
+
+    <email-c-coin-fill class="w-7 h-7"/>
+    <email-c-dataserver />
+
     <div class="gva-form-box">
       <el-form
         ref="emailForm"
```

4. 查看效果图
![image](https://github.com/user-attachments/assets/ae23da6a-fcf4-4056-8ccf-eb4c8efdee34)
