### PR TITLE
web/src/view/superAdmin/menu/icon.vue: 后台菜单管理中选择图标时增加可选自定义图标

### DIFF
--- a/web/src/view/superAdmin/menu/icon.vue
+++ b/web/src/view/superAdmin/menu/icon.vue
@@ -13,7 +13,7 @@
         </el-icon>
       </template>
       <el-option
-        v-for="item in options"
+        v-for="item in options.concat(config.logs)"
         :key="item.key"
         class="select__option_item"
         :label="item.key"
@@ -32,6 +32,7 @@
 
 <script setup>
   import { reactive } from 'vue'
+  import config from "@/core/config";
 
   defineOptions({
     name: 'Icon'


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/66173a52-eb0b-49e5-8788-4a8b535ddba3)
