### PR TITLE
fixed:修复表名是大写字母开头时，自动化代码异常问题。

### DIFF
--- a/web/src/view/systemTools/autoCode/index.vue
+++ b/web/src/view/systemTools/autoCode/index.vue
@@ -1326,8 +1326,8 @@
       const tbHump = toHump(dbform.value.tableName)
       form.value.structName = toUpperCase(tbHump)
       form.value.tableName = dbform.value.tableName
-      form.value.packageName = tbHump
-      form.value.abbreviation = tbHump
+      form.value.packageName = toLowerCase(tbHump)
+      form.value.abbreviation = toLowerCase(tbHump)
       form.value.description = tbHump + '表'
       form.value.autoCreateApiToSql = true
       form.value.fields = []


### PR DESCRIPTION
自动化代码时，点击使用此表。
问题一：
![image](https://github.com/user-attachments/assets/1fcb2739-e314-46d2-9138-2780c6c71bcd)
问题二：
因包名（form.value.packageName）是大写开头，导致生产代码是下划线开头，导致编译时报错。
![image](https://github.com/user-attachments/assets/dacc16d1-e2e2-42e2-9733-a52518b20cbe)
