### PR TITLE
修复可能的 context 泄露以及遗漏的错误处理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea/
 /web/node_modules
 /web/dist
 
@@ -33,3 +32,11 @@ server/uploads/
 *.iml
 web/.pnpm-debug.log
 web/pnpm-lock.yaml
+
+# binary files
+*.exe
+
+# SQLite database files
+*.db
+*.sqlite
+*.sqlite3

--- a/server/plugin/announcement/model/info.go
+++ b/server/plugin/announcement/model/info.go
@@ -8,10 +8,10 @@ import (
 // Info 公告 结构体
 type Info struct {
 	global.GVA_MODEL
-	Title       string         `json:"title" form:"title" gorm:"column:title;comment:公告标题;"`                                             //标题
-	Content     string         `json:"content" form:"content" gorm:"column:content;comment:公告内容;type:text;"`                             //内容
-	UserID      *int           `json:"userID" form:"userID" gorm:"column:user_id;comment:发布者;"`                                          //作者
-	Attachments datatypes.JSON `json:"attachments" form:"attachments" gorm:"column:attachments;comment:相关附件;"swaggertype:"array,object"` //附件
+	Title       string         `json:"title" form:"title" gorm:"column:title;comment:公告标题;"`                                              //标题
+	Content     string         `json:"content" form:"content" gorm:"column:content;comment:公告内容;type:text;"`                              //内容
+	UserID      *int           `json:"userID" form:"userID" gorm:"column:user_id;comment:发布者;"`                                           //作者
+	Attachments datatypes.JSON `json:"attachments" form:"attachments" gorm:"column:attachments;comment:相关附件;" swaggertype:"array,object"` //附件
 }
 
 // TableName 公告 Info自定义表名 gva_announcements_info

--- a/server/service/system/sys_casbin.go
+++ b/server/service/system/sys_casbin.go
@@ -87,12 +87,12 @@ func (casbinService *CasbinService) UpdateCasbinApi(oldPath string, newPath stri
 		"v1": newPath,
 		"v2": newMethod,
 	}).Error
-	e := casbinService.Casbin()
-	err = e.LoadPolicy()
 	if err != nil {
 		return err
 	}
-	return err
+
+	e := casbinService.Casbin()
+	return e.LoadPolicy()
 }
 
 //@author: [piexlmax](https://github.com/piexlmax)

--- a/server/utils/upload/minio_oss.go
+++ b/server/utils/upload/minio_oss.go
@@ -67,7 +67,6 @@ func (m *Minio) UploadFile(file *multipart.FileHeader) (filePathres, key string,
 	}
 	f.Close() // 创建文件 defer 关闭
 
-
 	// 对文件名进行加密存储
 	ext := filepath.Ext(file.Filename)
 	filename := utils.MD5V([]byte(strings.TrimSuffix(file.Filename, ext))) + ext
@@ -91,8 +90,10 @@ func (m *Minio) UploadFile(file *multipart.FileHeader) (filePathres, key string,
 }
 
 func (m *Minio) DeleteFile(key string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
 	// Delete the object from MinIO
-	ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
 	err := m.Client.RemoveObject(ctx, m.bucket, key, minio.RemoveObjectOptions{})
 	return err
 }


### PR DESCRIPTION
- `.gitignore`: 忽略 Windows 下编译的二进制文件和 SQLite 数据文件
- 修复结构体 tag 字段的错误使用, 结构体的 tag 字段的多个 key-value 对需要使用空格分隔
- 处理返回的 cancel 函数, 避免 context 泄露
- 修复 `UpdateCasbinApi` 方法遗漏的错误处理