### PR TITLE
生成模板中注释文档 query 修改

### DIFF
--- a/server/api/v1/system/sys_export_template.go
+++ b/server/api/v1/system/sys_export_template.go
@@ -213,7 +213,7 @@ func (sysExportTemplateApi *SysExportTemplateApi) ExportExcel(c *gin.Context) {
 // @Security ApiKeyAuth
 // @accept application/json
 // @Produce application/json
-// @Router /sysExportTemplate/exportExcel [get]
+// @Router /sysExportTemplate/ExportTemplate [get]
 func (sysExportTemplateApi *SysExportTemplateApi) ExportTemplate(c *gin.Context) {
 	templateID := c.Query("templateID")
 	if templateID == "" {

--- a/server/resource/package/server/api/api.go.tpl
+++ b/server/resource/package/server/api/api.go.tpl
@@ -130,7 +130,7 @@ func ({{.Abbreviation}}Api *{{.StructName}}Api) Update{{.StructName}}(c *gin.Con
 // @Security ApiKeyAuth
 // @accept application/json
 // @Produce application/json
-// @Param data query {{.PrimaryField.FieldJson}} true "用id查询{{.Description}}"
+// @Param data query {{.PrimaryField.FieldType}} true "用id查询{{.Description}}"
 // @Success 200 {object} response.Response{data={{.Package}}.{{.StructName}},msg=string} "查询成功"
 // @Router /{{.Abbreviation}}/find{{.StructName}} [get]
 func ({{.Abbreviation}}Api *{{.StructName}}Api) Find{{.StructName}}(c *gin.Context) {

--- a/server/resource/package/server/api/api.go.tpl
+++ b/server/resource/package/server/api/api.go.tpl
@@ -130,7 +130,7 @@ func ({{.Abbreviation}}Api *{{.StructName}}Api) Update{{.StructName}}(c *gin.Con
 // @Security ApiKeyAuth
 // @accept application/json
 // @Produce application/json
-// @Param data query {{.Package}}.{{.StructName}} true "用id查询{{.Description}}"
+// @Param data query {{.PrimaryField.FieldJson}} true "用id查询{{.Description}}"
 // @Success 200 {object} response.Response{data={{.Package}}.{{.StructName}},msg=string} "查询成功"
 // @Router /{{.Abbreviation}}/find{{.StructName}} [get]
 func ({{.Abbreviation}}Api *{{.StructName}}Api) Find{{.StructName}}(c *gin.Context) {


### PR DESCRIPTION
更新模板文件 `api.go.tpl` 中 `FindXxx` (即，用id查询Xxx) 接口，这会造成 swag init 提示，同时也符合接口描述

![image](https://github.com/user-attachments/assets/6ad00d32-11ab-4b03-9fc7-1253ff8ad129)

![image](https://github.com/user-attachments/assets/60e820fd-b840-4673-a80f-bb08e95a1d8b)

> [`swag`](https://github.com/swaggo/swag) 工具中，注释请求的 `query` 目前好像不用 ast 扫描对应结构体