### PR TITLE
Optimize JWT using `New()` instead of create instance directly

### DIFF
--- a/server/api/v1/system/sys_user.go
+++ b/server/api/v1/system/sys_user.go
@@ -1,18 +1,17 @@
 package system
 
 import (
-	"github.com/flipped-aurora/gin-vue-admin/server/model/common"
 	"strconv"
 	"time"
 
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
+	"github.com/flipped-aurora/gin-vue-admin/server/model/common"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/common/request"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/common/response"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/system"
 	systemReq "github.com/flipped-aurora/gin-vue-admin/server/model/system/request"
 	systemRes "github.com/flipped-aurora/gin-vue-admin/server/model/system/response"
 	"github.com/flipped-aurora/gin-vue-admin/server/utils"
-
 	"github.com/gin-gonic/gin"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
@@ -257,17 +256,17 @@ func (b *BaseApi) SetUserAuthority(c *gin.Context) {
 		return
 	}
 	claims := utils.GetUserInfo(c)
-	j := &utils.JWT{SigningKey: []byte(global.GVA_CONFIG.JWT.SigningKey)} // 唯一签名
 	claims.AuthorityId = sua.AuthorityId
-	if token, err := j.CreateToken(*claims); err != nil {
+	token, err := utils.NewJWT().CreateToken(*claims)
+	if err != nil {
 		global.GVA_LOG.Error("修改失败!", zap.Error(err))
 		response.FailWithMessage(err.Error(), c)
-	} else {
-		c.Header("new-token", token)
-		c.Header("new-expires-at", strconv.FormatInt(claims.ExpiresAt.Unix(), 10))
-		utils.SetToken(c, token, int((claims.ExpiresAt.Unix()-time.Now().Unix())/60))
-		response.OkWithMessage("修改成功", c)
+		return
 	}
+	c.Header("new-token", token)
+	c.Header("new-expires-at", strconv.FormatInt(claims.ExpiresAt.Unix(), 10))
+	utils.SetToken(c, token, int((claims.ExpiresAt.Unix()-time.Now().Unix())/60))
+	response.OkWithMessage("修改成功", c)
 }
 
 // SetUserAuthorities

--- a/server/utils/claims.go
+++ b/server/utils/claims.go
@@ -1,13 +1,14 @@
 package utils
 
 import (
+	"net"
+	"time"
+
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/system"
 	systemReq "github.com/flipped-aurora/gin-vue-admin/server/model/system/request"
 	"github.com/gin-gonic/gin"
 	"github.com/gofrs/uuid/v5"
-	"net"
-	"time"
 )
 
 func ClearToken(c *gin.Context) {
@@ -134,7 +135,7 @@ func GetUserName(c *gin.Context) string {
 }
 
 func LoginToken(user system.Login) (token string, claims systemReq.CustomClaims, err error) {
-	j := &JWT{SigningKey: []byte(global.GVA_CONFIG.JWT.SigningKey)} // 唯一签名
+	j := NewJWT()
 	claims = j.CreateClaims(systemReq.BaseClaims{
 		UUID:        user.GetUUID(),
 		ID:          user.GetUserId(),
@@ -143,8 +144,5 @@ func LoginToken(user system.Login) (token string, claims systemReq.CustomClaims,
 		AuthorityId: user.GetAuthorityId(),
 	})
 	token, err = j.CreateToken(claims)
-	if err != nil {
-		return
-	}
 	return
 }


### PR DESCRIPTION
- Refactor JWT token generation, use `New()` function instead of create instance directly.
- Improve error handling flow in `SetUserAuthority`, remove `else` block, to make the code more readable.
- Remove redundant `err != nil` judgment.