### PR TITLE
refactor: rename error with `Err` prefix to follow Go conventions

### DIFF
--- a/server/middleware/jwt.go
+++ b/server/middleware/jwt.go
@@ -2,16 +2,15 @@ package middleware
 
 import (
 	"errors"
-	"github.com/flipped-aurora/gin-vue-admin/server/global"
-	"github.com/flipped-aurora/gin-vue-admin/server/utils"
-	"github.com/golang-jwt/jwt/v4"
 	"strconv"
 	"time"
 
+	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/common/response"
 	"github.com/flipped-aurora/gin-vue-admin/server/service"
-
+	"github.com/flipped-aurora/gin-vue-admin/server/utils"
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 var jwtService = service.ServiceGroupApp.SystemServiceGroup.JwtService
@@ -35,7 +34,7 @@ func JWTAuth() gin.HandlerFunc {
 		// parseToken 解析token包含的信息
 		claims, err := j.ParseToken(token)
 		if err != nil {
-			if errors.Is(err, utils.TokenExpired) {
+			if errors.Is(err, utils.ErrTokenExpired) {
 				response.NoAuth("授权已过期", c)
 				utils.ClearToken(c)
 				c.Abort()

--- a/server/utils/breakpoint_continue.go
+++ b/server/utils/breakpoint_continue.go
@@ -55,7 +55,7 @@ func CheckMd5(content []byte, chunkMd5 string) (CanUpload bool) {
 //@return: string, error
 
 func makeFileContent(content []byte, fileName string, FileDir string, contentNumber int) (string, error) {
-	if strings.Index(fileName, "..") > -1 || strings.Index(FileDir, "..") > -1 {
+	if strings.Contains(fileName, "..") || strings.Contains(FileDir, "..") {
 		return "", errors.New("文件名或路径不合法")
 	}
 	path := FileDir + fileName + "_" + strconv.Itoa(contentNumber)

--- a/server/utils/jwt.go
+++ b/server/utils/jwt.go
@@ -4,10 +4,9 @@ import (
 	"errors"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt/v4"
-
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/system/request"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 type JWT struct {
@@ -15,10 +14,10 @@ type JWT struct {
 }
 
 var (
-	TokenExpired     = errors.New("Token is expired")
-	TokenNotValidYet = errors.New("Token not active yet")
-	TokenMalformed   = errors.New("That's not even a token")
-	TokenInvalid     = errors.New("Couldn't handle this token:")
+	ErrTokenExpired     = errors.New("token is expired")
+	ErrTokenNotValidYet = errors.New("token not active yet")
+	ErrTokenMalformed   = errors.New("that's not even a token")
+	ErrTokenInvalid     = errors.New("couldn't handle this token")
 )
 
 func NewJWT() *JWT {
@@ -65,14 +64,14 @@ func (j *JWT) ParseToken(tokenString string) (*request.CustomClaims, error) {
 	if err != nil {
 		if ve, ok := err.(*jwt.ValidationError); ok {
 			if ve.Errors&jwt.ValidationErrorMalformed != 0 {
-				return nil, TokenMalformed
+				return nil, ErrTokenMalformed
 			} else if ve.Errors&jwt.ValidationErrorExpired != 0 {
 				// Token is expired
-				return nil, TokenExpired
+				return nil, ErrTokenExpired
 			} else if ve.Errors&jwt.ValidationErrorNotValidYet != 0 {
-				return nil, TokenNotValidYet
+				return nil, ErrTokenNotValidYet
 			} else {
-				return nil, TokenInvalid
+				return nil, ErrTokenInvalid
 			}
 		}
 	}
@@ -80,9 +79,9 @@ func (j *JWT) ParseToken(tokenString string) (*request.CustomClaims, error) {
 		if claims, ok := token.Claims.(*request.CustomClaims); ok && token.Valid {
 			return claims, nil
 		}
-		return nil, TokenInvalid
+		return nil, ErrTokenInvalid
 
 	} else {
-		return nil, TokenInvalid
+		return nil, ErrTokenInvalid
 	}
 }

--- a/server/utils/zip.go
+++ b/server/utils/zip.go
@@ -19,7 +19,7 @@ func Unzip(zipFile string, destDir string) ([]string, error) {
 	defer zipReader.Close()
 
 	for _, f := range zipReader.File {
-		if strings.Index(f.Name, "..") > -1 {
+		if strings.Contains(f.Name, "..") {
 			return []string{}, fmt.Errorf("%s 文件名不合法", f.Name)
 		}
 		fpath := filepath.Join(destDir, f.Name)


### PR DESCRIPTION
- 使用 strings.Contains 替代 strings.Index 方法
- error 变量命名使用 `Err` 前缀修饰，且 error 信息为开头小写，具体参考 Go 官方规范 https://go.dev/wiki/CodeReviewComments#error-strings

This change improves code readability and follows better Go naming conventions for error variables.