### PR TITLE
fix: 分页栏居中显示

### DIFF
--- a/web/src/style/element_visiable.scss
+++ b/web/src/style/element_visiable.scss
@@ -11,7 +11,7 @@
 }
 
 .gva-pagination {
-  @apply flex justify-end;
+  @apply flex justify-center;
   .el-pagination__editor {
     .el-input__inner {
       @apply h-8;


### PR DESCRIPTION
实现“超级管理员->api管理”等含有分页栏的页面底部分页栏居中显示

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/fb4a21da-da85-4da8-b45e-0b7e129ed0e7" />
