### PR TITLE
refactor: separate config path acquisition to `getConfigPath()` function

### DIFF
--- a/server/core/viper.go
+++ b/server/core/viper.go
@@ -22,7 +22,7 @@ func Viper() *viper.Viper {
 	v.SetConfigType("yaml")
 	err := v.ReadInConfig()
 	if err != nil {
-		panic(fmt.Errorf("Fatal error config file: %s \n", err))
+		panic(fmt.Errorf("fatal error config file: %w", err))
 	}
 	v.WatchConfig()
 
@@ -33,7 +33,7 @@ func Viper() *viper.Viper {
 		}
 	})
 	if err = v.Unmarshal(&global.GVA_CONFIG); err != nil {
-		panic(err)
+		panic(fmt.Errorf("fatal error unmarshal config: %w", err))
 	}
 
 	// root 适配性 根据root位置去找到对应迁移位置,保证root路径有效
@@ -58,12 +58,19 @@ func getConfigPath() (config string) {
 
 	switch gin.Mode() { // 根据 gin 模式文件名
 	case gin.DebugMode:
-		config = internal.ConfigDefaultFile
+		config = internal.ConfigDebugFile
 	case gin.ReleaseMode:
 		config = internal.ConfigReleaseFile
 	case gin.TestMode:
 		config = internal.ConfigTestFile
 	}
 	fmt.Printf("您正在使用 gin 的 %s 模式运行, config 的路径为 %s\n", gin.Mode(), config)
+
+	_, err := os.Stat(config)
+	if err != nil || os.IsNotExist(err) {
+		config = internal.ConfigDefaultFile
+		fmt.Printf("配置文件路径不存在, 使用默认配置文件路径: %s\n", config)
+	}
+
 	return
 }

--- a/server/core/viper.go
+++ b/server/core/viper.go
@@ -3,48 +3,19 @@ package core
 import (
 	"flag"
 	"fmt"
-	"github.com/flipped-aurora/gin-vue-admin/server/core/internal"
-	"github.com/gin-gonic/gin"
 	"os"
 	"path/filepath"
 
-	"github.com/fsnotify/fsnotify"
-	"github.com/spf13/viper"
-
+	"github.com/flipped-aurora/gin-vue-admin/server/core/internal"
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
+	"github.com/fsnotify/fsnotify"
+	"github.com/gin-gonic/gin"
+	"github.com/spf13/viper"
 )
 
-// Viper //
-// 优先级: 命令行 > 环境变量 > 默认值
-// Author [SliverHorn](https://github.com/SliverHorn)
-func Viper(path ...string) *viper.Viper {
-	var config string
-
-	if len(path) == 0 {
-		flag.StringVar(&config, "c", "", "choose config file.")
-		flag.Parse()
-		if config == "" { // 判断命令行参数是否为空
-			if configEnv := os.Getenv(internal.ConfigEnv); configEnv == "" { // 判断 internal.ConfigEnv 常量存储的环境变量是否为空
-				switch gin.Mode() {
-				case gin.DebugMode:
-					config = internal.ConfigDefaultFile
-				case gin.ReleaseMode:
-					config = internal.ConfigReleaseFile
-				case gin.TestMode:
-					config = internal.ConfigTestFile
-				}
-				fmt.Printf("您正在使用gin模式的%s环境名称,config的路径为%s\n", gin.Mode(), config)
-			} else { // internal.ConfigEnv 常量存储的环境变量不为空 将值赋值于config
-				config = configEnv
-				fmt.Printf("您正在使用%s环境变量,config的路径为%s\n", internal.ConfigEnv, config)
-			}
-		} else { // 命令行参数不为空 将值赋值于config
-			fmt.Printf("您正在使用命令行的-c参数传递的值,config的路径为%s\n", config)
-		}
-	} else { // 函数传递的可变参数的第一个值赋值于config
-		config = path[0]
-		fmt.Printf("您正在使用func Viper()传递的值,config的路径为%s\n", config)
-	}
+// Viper 配置
+func Viper() *viper.Viper {
+	config := getConfigPath()
 
 	v := viper.New()
 	v.SetConfigFile(config)
@@ -68,4 +39,31 @@ func Viper(path ...string) *viper.Viper {
 	// root 适配性 根据root位置去找到对应迁移位置,保证root路径有效
 	global.GVA_CONFIG.AutoCode.Root, _ = filepath.Abs("..")
 	return v
+}
+
+// getConfigPath 获取配置文件路径, 优先级: 命令行 > 环境变量 > 默认值
+func getConfigPath() (config string) {
+	// `-c` flag parse
+	flag.StringVar(&config, "c", "", "choose config file.")
+	flag.Parse()
+	if config != "" { // 命令行参数不为空 将值赋值于config
+		fmt.Printf("您正在使用命令行的 '-c' 参数传递的值, config 的路径为 %s\n", config)
+		return
+	}
+	if env := os.Getenv(internal.ConfigEnv); env != "" { // 判断环境变量 GVA_CONFIG
+		config = env
+		fmt.Printf("您正在使用 %s 环境变量, config 的路径为 %s\n", internal.ConfigEnv, config)
+		return
+	}
+
+	switch gin.Mode() { // 根据 gin 模式文件名
+	case gin.DebugMode:
+		config = internal.ConfigDefaultFile
+	case gin.ReleaseMode:
+		config = internal.ConfigReleaseFile
+	case gin.TestMode:
+		config = internal.ConfigTestFile
+	}
+	fmt.Printf("您正在使用 gin 的 %s 模式运行, config 的路径为 %s\n", gin.Mode(), config)
+	return
 }


### PR DESCRIPTION
- Extract config path logic to separate `getConfigPath()` function.
- Simplify config priority handling: cmd flag > env variable > default by mode.
- Remove unnecessary param `path` for `viper()` function.
- Add fallback to default config path when mode-specific config file doesn't exist.