### PR TITLE
fix: add new rule to verify package name

### DIFF
--- a/web/src/view/systemTools/autoPkg/autoPkg.vue
+++ b/web/src/view/systemTools/autoPkg/autoPkg.vue
@@ -123,6 +123,8 @@
       callback(new Error('不能为中文'))
     } else if (/^\d+$/.test(value[0])) {
       callback(new Error('不能够以数字开头'))
+    } else if (!/^[a-zA-Z0-9_]+$/.test(value)) {
+      callback(new Error('只能包含英文字母、数字和下划线'))
     } else {
       callback()
     }


### PR DESCRIPTION
prevent autocode's package name don't conform to the naming rule of golang.

golang only apply [a-zA-z0-9_]