### PR TITLE
sys_export_template.go: Fix function ImportExcel for generating SQL correctly

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,7 @@
       content="Gin,Vue,Admin.Gin-Vue-Admin,GVA,gin-vue-admin,后台管理框架,vue后台管理框架,gin-vue-admin文档,gin-vue-admin首页,gin-vue-admin"
       name="keywords"
     />
-    <link rel="icon" href="favicon.ico" />
+    <link rel="icon" href="/favicon.ico" />
     <title></title>
     <style>
       .transition-colors {


### PR DESCRIPTION
(1)Fix function ImportExcel for generating SQL correctly: Check excel title, remove the leading and trailing white spaces, skip the extra fields.修复表格标题行首尾空不匹配或多余的标题导致的SQL语句错误问题：去掉表格标题首尾空字符，并跳过多余的字段

(2)Fix icon path in the file index.html. 修复build之后icon路径问题