### PR TITLE
fix: 修复代码生成中时间和富文本的搜索错误

### DIFF
--- a/server/utils/autocode/template_funcs.go
+++ b/server/utils/autocode/template_funcs.go
@@ -112,7 +112,7 @@ func GenerateSearchConditions(fields []*systemReq.AutoCodeField) string {
 
 		var condition string
 
-		if slices.Contains([]string{"enum", "pictures", "picture", "video", "json", "array"}, field.FieldType) {
+		if slices.Contains([]string{"enum", "pictures", "picture", "video", "json", "richtext", "array"}, field.FieldType) {
 			if field.FieldType == "enum" {
 				if field.FieldSearchType == "LIKE" {
 					condition = fmt.Sprintf(`
@@ -690,7 +690,7 @@ func GenerateSearchField(field systemReq.AutoCodeField) string {
 		// 生成普通搜索字段
 		if field.FieldType == "enum" || field.FieldType == "picture" ||
 			field.FieldType == "pictures" || field.FieldType == "video" ||
-			field.FieldType == "json" || field.FieldType == "array" {
+			field.FieldType == "json" || field.FieldType == "richtext" || field.FieldType == "array" {
 			result = fmt.Sprintf("%s  string `json:\"%s\" form:\"%s\"` ",
 				field.FieldName, field.FieldJson, field.FieldJson)
 		} else {

--- a/server/utils/autocode/template_funcs.go
+++ b/server/utils/autocode/template_funcs.go
@@ -140,7 +140,7 @@ func GenerateSearchConditions(fields []*systemReq.AutoCodeField) string {
 			if len(info.%sRange) == 2 {
 				db = db.Where("%s %s ? AND ? ", info.%sRange[0], info.%sRange[1])
 			}`,
-					field.FieldName, field.FieldName, field.ColumnName, field.FieldSearchType, field.FieldName, field.FieldName)
+					field.FieldName, field.ColumnName, field.FieldSearchType, field.FieldName, field.FieldName)
 			} else {
 				condition = fmt.Sprintf(`
 	if info.Start%s != nil && info.End%s != nil {
@@ -690,7 +690,7 @@ func GenerateSearchField(field systemReq.AutoCodeField) string {
 		// 生成普通搜索字段
 		if field.FieldType == "enum" || field.FieldType == "picture" ||
 			field.FieldType == "pictures" || field.FieldType == "video" ||
-			field.FieldType == "json" || field.FieldType == "richtext" || field.FieldType == "array" {
+			field.FieldType == "json" || field.FieldType == "array" {
 			result = fmt.Sprintf("%s  string `json:\"%s\" form:\"%s\"` ",
 				field.FieldName, field.FieldJson, field.FieldJson)
 		} else {


### PR DESCRIPTION
富文本中原有搜索条件为 `if %s && *info.%s != ""` 与创建的struct类型不匹配