### PR TITLE
fix: 修复在多库模式下生成代码时候用默认库用错的情况

### DIFF
--- a/server/resource/package/server/service/service.go.tpl
+++ b/server/resource/package/server/service/service.go.tpl
@@ -195,7 +195,7 @@ func ({{.Abbreviation}}Service *{{.StructName}}Service)Get{{.StructName}}DataSou
 	   {{$key}} := make([]map[string]any, 0)
 	   {{ $dataDB := "" }}
 	   {{- if eq $value.DBName "" }}
-       {{ $dataDB = $db }}
+       {{ $dataDB = "global.GVA_DB" }}
        {{- else}}
        {{ $dataDB = printf "global.MustGetGlobalDBByDBName(\"%s\")" $value.DBName }}
        {{- end}}


### PR DESCRIPTION
在多库模式下生成代码时 选择关联模型时候如果选默认库如图
![image](https://github.com/user-attachments/assets/fd2d4494-c098-4268-9bd9-cb3caf853863)
传的参数如下
![cb3d60c266dce4a32176fc149ba47238](https://github.com/user-attachments/assets/012ecef2-6730-4d23-9e4d-277d45fd308b)
生成的代码问题部分
![cec7d09d7a457b0b50457401f4e0e21c](https://github.com/user-attachments/assets/d4f9400f-b62c-4dc3-8590-ef510ebdcd65)

### 【问题】
**一个字段用了gva默认库 但是生成的代码两个都是用的业务库**

下面是定位的问题修改bug
![89b24c57ec3ebe55a754a14e9f70df31](https://github.com/user-attachments/assets/0224b2bb-9da0-437f-8df4-5c1aeb9f681e)


