### PR TITLE
fix: #2030 富文本编辑器全屏时部分内容会被其他表单项遮挡

### DIFF
--- a/web/src/components/richtext/rich-edit.vue
+++ b/web/src/components/richtext/rich-edit.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="border border-solid border-gray-100 h-full">
+  <div class="border border-solid border-gray-100 h-full z-10">
     <Toolbar
       :editor="editorRef"
       :default-config="toolbarConfig"
@@ -83,4 +83,6 @@
   )
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+
+</style>


### PR DESCRIPTION
#2030 