### PR TITLE
新增支持LoginAuth认证方式适用于IBM、微软等部分邮箱服务

### DIFF
--- a/server/config/email.go
+++ b/server/config/email.go
@@ -1,11 +1,12 @@
 package config
 
 type Email struct {
-	To       string `mapstructure:"to" json:"to" yaml:"to"`                   // 收件人:多个以英文逗号分隔 例：a@qq.com b@qq.com 正式开发中请把此项目作为参数使用
-	From     string `mapstructure:"from" json:"from" yaml:"from"`             // 发件人  你自己要发邮件的邮箱
-	Host     string `mapstructure:"host" json:"host" yaml:"host"`             // 服务器地址 例如 smtp.qq.com  请前往QQ或者你要发邮件的邮箱查看其smtp协议
-	Secret   string `mapstructure:"secret" json:"secret" yaml:"secret"`       // 密钥    用于登录的密钥 最好不要用邮箱密码 去邮箱smtp申请一个用于登录的密钥
-	Nickname string `mapstructure:"nickname" json:"nickname" yaml:"nickname"` // 昵称    发件人昵称 通常为自己的邮箱
-	Port     int    `mapstructure:"port" json:"port" yaml:"port"`             // 端口     请前往QQ或者你要发邮件的邮箱查看其smtp协议 大多为 465
-	IsSSL    bool   `mapstructure:"is-ssl" json:"is-ssl" yaml:"is-ssl"`       // 是否SSL   是否开启SSL
+	To          string `mapstructure:"to" json:"to" yaml:"to"`                               // 收件人:多个以英文逗号分隔 例：a@qq.com b@qq.com 正式开发中请把此项目作为参数使用
+	From        string `mapstructure:"from" json:"from" yaml:"from"`                         // 发件人  你自己要发邮件的邮箱
+	Host        string `mapstructure:"host" json:"host" yaml:"host"`                         // 服务器地址 例如 smtp.qq.com  请前往QQ或者你要发邮件的邮箱查看其smtp协议
+	Secret      string `mapstructure:"secret" json:"secret" yaml:"secret"`                   // 密钥    用于登录的密钥 最好不要用邮箱密码 去邮箱smtp申请一个用于登录的密钥
+	Nickname    string `mapstructure:"nickname" json:"nickname" yaml:"nickname"`             // 昵称    发件人昵称 通常为自己的邮箱
+	Port        int    `mapstructure:"port" json:"port" yaml:"port"`                         // 端口     请前往QQ或者你要发邮件的邮箱查看其smtp协议 大多为 465
+	IsSSL       bool   `mapstructure:"is-ssl" json:"is-ssl" yaml:"is-ssl"`                   // 是否SSL   是否开启SSL
+	IsLoginAuth bool   `mapstructure:"is-loginauth" json:"is-loginauth" yaml:"is-loginauth"` // 是否LoginAuth   是否使用LoginAuth认证方式（适用于IBM、微软邮箱服务器等）
 }

--- a/server/initialize/plugin_biz_v1.go
+++ b/server/initialize/plugin_biz_v1.go
@@ -2,6 +2,7 @@ package initialize
 
 import (
 	"fmt"
+
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/plugin/email"
 	"github.com/flipped-aurora/gin-vue-admin/server/utils/plugin"
@@ -29,6 +30,7 @@ func bizPluginV1(group ...*gin.RouterGroup) {
 		global.GVA_CONFIG.Email.Nickname,
 		global.GVA_CONFIG.Email.Port,
 		global.GVA_CONFIG.Email.IsSSL,
+		global.GVA_CONFIG.Email.IsLoginAuth,
 	))
 	holder(public, private)
 }

--- a/server/plugin/email/README.MD
+++ b/server/plugin/email/README.MD
@@ -14,6 +14,7 @@
 		global.GVA_CONFIG.Email.Nickname,
 		global.GVA_CONFIG.Email.Port,
 		global.GVA_CONFIG.Email.IsSSL,
+		global.GVA_CONFIG.Email.IsLoginAuth,
 		))
 
     同样也可以再传入时写死
@@ -26,6 +27,7 @@
     "登录密钥",
     465,
     true,
+    true,
     ))
 
 ### 2. 配置说明
@@ -34,13 +36,14 @@
     //其中 Form 和 Secret 通常来说就是用户名和密码
 
     type Email struct {
-	    To       string  // 收件人:多个以英文逗号分隔 例：a@qq.com b@qq.com 正式开发中请把此项目作为参数使用 此处配置主要用于发送错误监控邮件
-	    From     string  // 发件人  你自己要发邮件的邮箱
-	    Host     string  // 服务器地址 例如 smtp.qq.com  请前往QQ或者你要发邮件的邮箱查看其smtp协议
-	    Secret   string  // 密钥    用于登录的密钥 最好不要用邮箱密码 去邮箱smtp申请一个用于登录的密钥
-	    Nickname string  // 昵称    发件人昵称 自定义即可 可以不填
-	    Port     int     // 端口     请前往QQ或者你要发邮件的邮箱查看其smtp协议 大多为 465
-	    IsSSL    bool    // 是否SSL   是否开启SSL
+	    To          string  // 收件人:多个以英文逗号分隔 例：a@qq.com b@qq.com 正式开发中请把此项目作为参数使用 此处配置主要用于发送错误监控邮件
+	    From        string  // 发件人  你自己要发邮件的邮箱
+	    Host        string  // 服务器地址 例如 smtp.qq.com  请前往QQ或者你要发邮件的邮箱查看其smtp协议
+	    Secret      string  // 密钥    用于登录的密钥 最好不要用邮箱密码 去邮箱smtp申请一个用于登录的密钥
+	    Nickname    string  // 昵称    发件人昵称 自定义即可 可以不填
+	    Port        int     // 端口     请前往QQ或者你要发邮件的邮箱查看其smtp协议 大多为 465
+	    IsSSL       bool    // 是否SSL   是否开启SSL
+	    IsLoginAuth bool    // 是否LoginAuth   是否使用LoginAuth认证方式（适用于IBM、微软邮箱服务器等）
     }
 #### 2-2 入参结构说明
     //其中 Form 和 Secret 通常来说就是用户名和密码

--- a/server/plugin/email/config/email.go
+++ b/server/plugin/email/config/email.go
@@ -1,11 +1,12 @@
 package config
 
 type Email struct {
-	To       string `mapstructure:"to" json:"to" yaml:"to"`                   // 收件人:多个以英文逗号分隔 例：a@qq.com b@qq.com 正式开发中请把此项目作为参数使用
-	From     string `mapstructure:"from" json:"from" yaml:"from"`             // 发件人  你自己要发邮件的邮箱
-	Host     string `mapstructure:"host" json:"host" yaml:"host"`             // 服务器地址 例如 smtp.qq.com  请前往QQ或者你要发邮件的邮箱查看其smtp协议
-	Secret   string `mapstructure:"secret" json:"secret" yaml:"secret"`       // 密钥    用于登录的密钥 最好不要用邮箱密码 去邮箱smtp申请一个用于登录的密钥
-	Nickname string `mapstructure:"nickname" json:"nickname" yaml:"nickname"` // 昵称    发件人昵称 通常为自己的邮箱
-	Port     int    `mapstructure:"port" json:"port" yaml:"port"`             // 端口     请前往QQ或者你要发邮件的邮箱查看其smtp协议 大多为 465
-	IsSSL    bool   `mapstructure:"is-ssl" json:"isSSL" yaml:"is-ssl"`        // 是否SSL   是否开启SSL
+	To          string `mapstructure:"to" json:"to" yaml:"to"`                               // 收件人:多个以英文逗号分隔 例：a@qq.com b@qq.com 正式开发中请把此项目作为参数使用
+	From        string `mapstructure:"from" json:"from" yaml:"from"`                         // 发件人  你自己要发邮件的邮箱
+	Host        string `mapstructure:"host" json:"host" yaml:"host"`                         // 服务器地址 例如 smtp.qq.com  请前往QQ或者你要发邮件的邮箱查看其smtp协议
+	Secret      string `mapstructure:"secret" json:"secret" yaml:"secret"`                   // 密钥    用于登录的密钥 最好不要用邮箱密码 去邮箱smtp申请一个用于登录的密钥
+	Nickname    string `mapstructure:"nickname" json:"nickname" yaml:"nickname"`             // 昵称    发件人昵称 通常为自己的邮箱
+	Port        int    `mapstructure:"port" json:"port" yaml:"port"`                         // 端口     请前往QQ或者你要发邮件的邮箱查看其smtp协议 大多为 465
+	IsSSL       bool   `mapstructure:"is-ssl" json:"isSSL" yaml:"is-ssl"`                    // 是否SSL   是否开启SSL
+	IsLoginAuth bool   `mapstructure:"is-loginauth" json:"is-loginauth" yaml:"is-loginauth"` // 是否LoginAuth   是否使用LoginAuth认证
 }

--- a/server/plugin/email/main.go
+++ b/server/plugin/email/main.go
@@ -8,7 +8,7 @@ import (
 
 type emailPlugin struct{}
 
-func CreateEmailPlug(To, From, Host, Secret, Nickname string, Port int, IsSSL bool) *emailPlugin {
+func CreateEmailPlug(To, From, Host, Secret, Nickname string, Port int, IsSSL bool, IsLoginAuth bool) *emailPlugin {
 	global.GlobalConfig.To = To
 	global.GlobalConfig.From = From
 	global.GlobalConfig.Host = Host
@@ -16,6 +16,7 @@ func CreateEmailPlug(To, From, Host, Secret, Nickname string, Port int, IsSSL bo
 	global.GlobalConfig.Nickname = Nickname
 	global.GlobalConfig.Port = Port
 	global.GlobalConfig.IsSSL = IsSSL
+	global.GlobalConfig.IsLoginAuth = IsLoginAuth
 	return &emailPlugin{}
 }
 

--- a/web/src/view/systemTools/system/system.vue
+++ b/web/src/view/systemTools/system/system.vue
@@ -202,6 +202,9 @@
           <el-form-item label="是否为ssl">
             <el-switch v-model="config.email['is-ssl']" />
           </el-form-item>
+          <el-form-item label="是否LoginAuth认证">
+            <el-switch v-model="config.email['is-loginauth']" />
+          </el-form-item>
           <el-form-item label="secret">
             <el-input
               v-model.trim="config.email.secret"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ddf97e1a-b37b-4c8a-9774-934e6181f4dd)
IBM、微软等部分邮箱服务不支持标准库中的PlainAuth认证，仅支持LoginAuth认证，增加配置项