### PR TITLE
fix: 修复不小心选择业务库后想删掉的问题

### DIFF
--- a/web/src/view/systemTools/autoCode/index.vue
+++ b/web/src/view/systemTools/autoCode/index.vue
@@ -307,6 +307,7 @@
               </template>
               <el-select
                 v-model="form.businessDB"
+                clearable
                 placeholder="选择业务库"
                 class="w-full"
               >


### PR DESCRIPTION
### 生成代码选择业务库的时候，如果不小心选了一个业务库 想删掉用gva库 没有提供删除选项。我给加了一个clearable。可删除的

![03b7a252df194e666bafc7b888ab4cba](https://github.com/user-attachments/assets/0e9a767a-34ce-4eaa-8506-36dff1d44028)
![image](https://github.com/user-attachments/assets/8723e964-e81d-4d16-8c23-81f0a9aba558)
