### PR TITLE
sys_authority.go: Fix a potential nil pointer dereference in GetParentAuthorityID

### DIFF
--- a/server/service/system/sys_authority.go
+++ b/server/service/system/sys_authority.go
@@ -326,5 +326,8 @@ func (authorityService *AuthorityService) findChildrenAuthority(authority *syste
 func (authorityService *AuthorityService) GetParentAuthorityID(authorityID uint) (parentID uint, err error) {
 	var authority system.SysAuthority
 	err = global.GVA_DB.Where("authority_id = ?", authorityID).First(&authority).Error
-	return *authority.ParentId, err
+	if err != nil {
+		return
+	}
+	return *authority.ParentId, nil
 }


### PR DESCRIPTION
修复了在数据库状态异常时，角色权限管理页面相关接口调用GetParentAuthorityID会发生panic的问题