### PR TITLE
头部导航栏里的菜单无法正常渲染出来的bug

### DIFF
--- a/web/src/components/commandMenu/index.vue
+++ b/web/src/components/commandMenu/index.vue
@@ -55,7 +55,6 @@
   const deepMenus = (menus) => {
     const arr = []
     menus?.forEach((menu) => {
-      if (!menu?.children) return
       if (menu.children && menu.children.length > 0) {
         arr.push(...deepMenus(menu.children))
       } else {


### PR DESCRIPTION
菜单循环中没有子菜单就直接返回，没有添加到arr列表中导致arr始终是空的