### PR TITLE
fix:修复查询条件无法添加问题

### DIFF
--- a/web/src/view/systemTools/autoCode/index.vue
+++ b/web/src/view/systemTools/autoCode/index.vue
@@ -697,7 +697,7 @@
                 style="width: 100%"
                 placeholder="请选择字段查询条件"
                 clearable
-                :disabled="row.fieldType !== 'json' || row.disabled"
+                :disabled="row.fieldType === 'json' || row.disabled"
               >
                 <el-option
                   v-for="item in typeSearchOptions"


### PR DESCRIPTION
这里判断错了，应该是json类型的字段才禁用查询，而不是非json就禁用