### PR TITLE
Fix Server 返回非 JSON 响应数据时导致错误弹窗

### DIFF
--- a/web/src/utils/request.js
+++ b/web/src/utils/request.js
@@ -77,6 +77,9 @@ service.interceptors.response.use(
     if (response.headers['new-token']) {
       userStore.setToken(response.headers['new-token'])
     }
+    if (typeof response.data.code === 'undefined') {
+      return response
+    }
     if (response.data.code === 0 || response.headers.success === 'true') {
       if (response.headers.msg) {
         response.data.msg = decodeURI(response.headers.msg)


### PR DESCRIPTION
服务端以 c.File 返回响应数据时，Response 没有 code 字段，会导致页面触发错误弹窗信息：undefined