### PR TITLE
refactor: move `freshCasbin` route to private and remove unused param

### DIFF
--- a/server/initialize/router.go
+++ b/server/initialize/router.go
@@ -88,7 +88,7 @@ func Routers() *gin.Engine {
 	}
 
 	{
-		systemRouter.InitApiRouter(PrivateGroup, PublicGroup)               // 注册功能api路由
+		systemRouter.InitApiRouter(PrivateGroup)                            // 注册功能api路由
 		systemRouter.InitJwtRouter(PrivateGroup)                            // jwt相关路由
 		systemRouter.InitUserRouter(PrivateGroup)                           // 注册用户路由
 		systemRouter.InitMenuRouter(PrivateGroup)                           // 注册menu路由
@@ -102,11 +102,10 @@ func Routers() *gin.Engine {
 		systemRouter.InitSysDictionaryDetailRouter(PrivateGroup)            // 字典详情管理
 		systemRouter.InitAuthorityBtnRouterRouter(PrivateGroup)             // 按钮权限管理
 		systemRouter.InitSysExportTemplateRouter(PrivateGroup, PublicGroup) // 导出模板
-		systemRouter.InitSysParamsRouter(PrivateGroup, PublicGroup)         // 参数管理
+		systemRouter.InitSysParamsRouter(PrivateGroup)                      // 参数管理
 		exampleRouter.InitCustomerRouter(PrivateGroup)                      // 客户路由
 		exampleRouter.InitFileUploadAndDownloadRouter(PrivateGroup)         // 文件上传下载功能路由
 		exampleRouter.InitAttachmentCategoryRouterRouter(PrivateGroup)      // 文件上传下载分类
-
 	}
 
 	//插件路由安装

--- a/server/router/system/sys_api.go
+++ b/server/router/system/sys_api.go
@@ -10,8 +10,6 @@ type ApiRouter struct{}
 func (s *ApiRouter) InitApiRouter(Router *gin.RouterGroup, RouterPub *gin.RouterGroup) {
 	apiRouter := Router.Group("api").Use(middleware.OperationRecord())
 	apiRouterWithoutRecord := Router.Group("api")
-
-	apiPublicRouterWithoutRecord := RouterPub.Group("api")
 	{
 		apiRouter.GET("getApiGroups", apiRouterApi.GetApiGroups)          // 获取路由组
 		apiRouter.GET("syncApi", apiRouterApi.SyncApi)                    // 同步Api
@@ -24,10 +22,8 @@ func (s *ApiRouter) InitApiRouter(Router *gin.RouterGroup, RouterPub *gin.Router
 		apiRouter.DELETE("deleteApisByIds", apiRouterApi.DeleteApisByIds) // 删除选中api
 	}
 	{
-		apiRouterWithoutRecord.POST("getAllApis", apiRouterApi.GetAllApis) // 获取所有api
-		apiRouterWithoutRecord.POST("getApiList", apiRouterApi.GetApiList) // 获取Api列表
-	}
-	{
-		apiPublicRouterWithoutRecord.GET("freshCasbin", apiRouterApi.FreshCasbin) // 刷新casbin权限
+		apiRouterWithoutRecord.POST("getAllApis", apiRouterApi.GetAllApis)  // 获取所有api
+		apiRouterWithoutRecord.POST("getApiList", apiRouterApi.GetApiList)  // 获取Api列表
+		apiRouterWithoutRecord.GET("freshCasbin", apiRouterApi.FreshCasbin) // 刷新casbin权限
 	}
 }

--- a/server/router/system/sys_api.go
+++ b/server/router/system/sys_api.go
@@ -7,7 +7,7 @@ import (
 
 type ApiRouter struct{}
 
-func (s *ApiRouter) InitApiRouter(Router *gin.RouterGroup, RouterPub *gin.RouterGroup) {
+func (s *ApiRouter) InitApiRouter(Router *gin.RouterGroup) {
 	apiRouter := Router.Group("api").Use(middleware.OperationRecord())
 	apiRouterWithoutRecord := Router.Group("api")
 	{

--- a/server/router/system/sys_params.go
+++ b/server/router/system/sys_params.go
@@ -8,7 +8,7 @@ import (
 type SysParamsRouter struct{}
 
 // InitSysParamsRouter 初始化 参数 路由信息
-func (s *SysParamsRouter) InitSysParamsRouter(Router *gin.RouterGroup, PublicRouter *gin.RouterGroup) {
+func (s *SysParamsRouter) InitSysParamsRouter(Router *gin.RouterGroup) {
 	sysParamsRouter := Router.Group("sysParams").Use(middleware.OperationRecord())
 	sysParamsRouterWithoutRecord := Router.Group("sysParams")
 	{

--- a/server/router/system/sys_user.go
+++ b/server/router/system/sys_user.go
@@ -18,7 +18,7 @@ func (s *UserRouter) InitUserRouter(Router *gin.RouterGroup) {
 		userRouter.PUT("setUserInfo", baseApi.SetUserInfo)                // 设置用户信息
 		userRouter.PUT("setSelfInfo", baseApi.SetSelfInfo)                // 设置自身信息
 		userRouter.POST("setUserAuthorities", baseApi.SetUserAuthorities) // 设置用户权限组
-		userRouter.POST("resetPassword", baseApi.ResetPassword)           // 设置用户权限组
+		userRouter.POST("resetPassword", baseApi.ResetPassword)           // 重置用户密码
 		userRouter.PUT("setSelfSetting", baseApi.SetSelfSetting)          // 用户界面配置
 	}
 	{


### PR DESCRIPTION
- Move `freshCasbin` route from public to private router group.
- Fix incorrect comment for `resetPassword` route.
- Remove unused `PublicGroup` parameter from `InitSysParamsRouter` and `InitApiRouter` method signatures