### PR TITLE
optimize: select and update necessary fields in `ChangePassword` method

### DIFF
--- a/server/api/v1/system/sys_user.go
+++ b/server/api/v1/system/sys_user.go
@@ -184,7 +184,7 @@ func (b *BaseApi) ChangePassword(c *gin.Context) {
 	}
 	uid := utils.GetUserID(c)
 	u := &system.SysUser{GVA_MODEL: global.GVA_MODEL{ID: uid}, Password: req.Password}
-	_, err = userService.ChangePassword(u, req.NewPassword)
+	err = userService.ChangePassword(u, req.NewPassword)
 	if err != nil {
 		global.GVA_LOG.Error("修改失败!", zap.Error(err))
 		response.FailWithMessage("修改失败，原密码与当前账户不符", c)

--- a/server/service/system/sys_user.go
+++ b/server/service/system/sys_user.go
@@ -3,9 +3,10 @@ package system
 import (
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/flipped-aurora/gin-vue-admin/server/model/common"
 	systemReq "github.com/flipped-aurora/gin-vue-admin/server/model/system/request"
-	"time"
 
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/system"
@@ -63,20 +64,20 @@ func (userService *UserService) Login(u *system.SysUser) (userInter *system.SysU
 //@function: ChangePassword
 //@description: 修改用户密码
 //@param: u *model.SysUser, newPassword string
-//@return: userInter *model.SysUser,err error
+//@return: err error
 
-func (userService *UserService) ChangePassword(u *system.SysUser, newPassword string) (userInter *system.SysUser, err error) {
+func (userService *UserService) ChangePassword(u *system.SysUser, newPassword string) (err error) {
 	var user system.SysUser
-	if err = global.GVA_DB.Where("id = ?", u.ID).First(&user).Error; err != nil {
-		return nil, err
+	err = global.GVA_DB.Select("id, password").Where("id = ?", u.ID).First(&user).Error
+	if err != nil {
+		return err
 	}
 	if ok := utils.BcryptCheck(u.Password, user.Password); !ok {
-		return nil, errors.New("原密码错误")
+		return errors.New("原密码错误")
 	}
-	user.Password = utils.BcryptHash(newPassword)
-	err = global.GVA_DB.Save(&user).Error
-	return &user, err
-
+	pwd := utils.BcryptHash(newPassword)
+	err = global.GVA_DB.Model(&user).Update("password", pwd).Error
+	return err
 }
 
 //@author: [piexlmax](https://github.com/piexlmax)


### PR DESCRIPTION
- Simplify `ChangePassword` method signature by removing unnecessary return type.
- Use `Select()` to fetch only the necessary fields (`id` and `password`) from the database.
- Replace `Save()` with `Update()` for more efficient password update operation.

Note: use `Save(&user)` to update the whole user record, which will cover other unchanged fields as well, causing data inconsistency when data race conditions.

使用 update 替换 save，同时只更新要更新的字段，避免数据竞争时全覆盖造成数据错误。