### PR TITLE
Fix captcha validation issue when `OpenCaptcha` option is disabled

### DIFF
--- a/server/api/v1/system/sys_user.go
+++ b/server/api/v1/system/sys_user.go
@@ -47,7 +47,7 @@ func (b *BaseApi) Login(c *gin.Context) {
 	}
 
 	var oc bool = openCaptcha == 0 || openCaptcha < interfaceToInt(v)
-	if oc && !store.Verify(l.CaptchaId, l.Captcha, true) {
+	if oc && (l.Captcha == "" || l.CaptchaId == "" || !store.Verify(l.CaptchaId, l.Captcha, true)) {
 		// 验证码次数+1
 		global.BlackCache.Increment(key, 1)
 		response.FailWithMessage("验证码错误", c)

--- a/server/utils/verify.go
+++ b/server/utils/verify.go
@@ -5,7 +5,7 @@ var (
 	ApiVerify              = Rules{"Path": {NotEmpty()}, "Description": {NotEmpty()}, "ApiGroup": {NotEmpty()}, "Method": {NotEmpty()}}
 	MenuVerify             = Rules{"Path": {NotEmpty()}, "Name": {NotEmpty()}, "Component": {NotEmpty()}, "Sort": {Ge("0")}}
 	MenuMetaVerify         = Rules{"Title": {NotEmpty()}}
-	LoginVerify            = Rules{"CaptchaId": {NotEmpty()}, "Captcha": {NotEmpty()}, "Username": {NotEmpty()}, "Password": {NotEmpty()}}
+	LoginVerify            = Rules{"Username": {NotEmpty()}, "Password": {NotEmpty()}}
 	RegisterVerify         = Rules{"Username": {NotEmpty()}, "NickName": {NotEmpty()}, "Password": {NotEmpty()}, "AuthorityId": {NotEmpty()}}
 	PageInfoVerify         = Rules{"Page": {NotEmpty()}, "PageSize": {NotEmpty()}}
 	CustomerVerify         = Rules{"CustomerName": {NotEmpty()}, "CustomerPhoneData": {NotEmpty()}}


### PR DESCRIPTION
Remove `CaptchaId` and `Captcha` fields from `LoginVerify` validation, and move captcha validation logic to the login handler.
Fix captcha validation issue when `OpenCaptcha` option is disabled.

refer #2063