### PR TITLE
修改gorm-oracle的驱动包为go-ora,不再依赖cgo和oracle instant  client

### DIFF
--- a/server/config/gorm_oracle.go
+++ b/server/config/gorm_oracle.go
@@ -1,10 +1,18 @@
 package config
 
+import (
+	"fmt"
+	"net"
+	"net/url"
+)
+
 type Oracle struct {
 	GeneralDB `yaml:",inline" mapstructure:",squash"`
 }
 
 func (m *Oracle) Dsn() string {
-	return "oracle://" + m.Username + ":" + m.Password + "@" + m.Path + ":" + m.Port + "/" + m.Dbname + "?" + m.Config
+	dsn := fmt.Sprintf("oracle://%s:%s@%s/%s?%s", url.PathEscape(m.Username), url.PathEscape(m.Password),
+		net.JoinHostPort(m.Path, m.Port), url.PathEscape(m.Dbname), m.Config)
+	return dsn
 
 }

--- a/server/initialize/gorm_oracle.go
+++ b/server/initialize/gorm_oracle.go
@@ -1,18 +1,14 @@
 package initialize
 
 import (
-	//"github.com/dzwvip/oracle"
+	oracle "github.com/dzwvip/gorm-oracle"
 	"github.com/flipped-aurora/gin-vue-admin/server/config"
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/initialize/internal"
-
-	//_ "github.com/godror/godror"
-	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
 
 // GormOracle 初始化oracle数据库
-// 如果需要Oracle库 放开import里的注释 把下方 mysql.Config 改为 oracle.Config ;  mysql.New 改为 oracle.New
 func GormOracle() *gorm.DB {
 	m := global.GVA_CONFIG.Oracle
 	return initOracleDatabase(m)
@@ -28,13 +24,7 @@ func initOracleDatabase(m config.Oracle) *gorm.DB {
 	if m.Dbname == "" {
 		return nil
 	}
-
-	oracleConfig := mysql.Config{
-		DSN:               m.Dsn(), // DSN data source name
-		DefaultStringSize: 191,     // string 类型字段的默认长度
-	}
-
-	if db, err := gorm.Open(mysql.New(oracleConfig), internal.Gorm.Config(m.Prefix, m.Singular)); err != nil {
+	if db, err := gorm.Open(oracle.Open(m.Dsn()), internal.Gorm.Config(m.Prefix, m.Singular)); err != nil {
 		panic(err)
 	} else {
 		sqlDB, _ := db.DB()

--- a/server/service/system/sys_auto_code_oracle.go
+++ b/server/service/system/sys_auto_code_oracle.go
@@ -64,7 +64,7 @@ WHERE
     lower(a.table_name) = ?
     AND lower(a.OWNER) = ?
 ORDER BY
-    a.COLUMN_ID;
+    a.COLUMN_ID
 `
 
 	err = global.GVA_DBList[businessDB].Raw(sql, tableName, dbName).Scan(&entities).Error


### PR DESCRIPTION
修改gorm-oracle的驱动包为go-ora(Pure go oracle client),不再依赖cgo和oracle instant client