### PR TITLE
feat: add autoMigrate config

### DIFF
--- a/server/config.yaml
+++ b/server/config.yaml
@@ -87,6 +87,8 @@ system:
     router-prefix: ""
     #  严格角色模式 打开后权限将会存在上下级关系
     use-strict-auth: false
+    #  自动迁移数据库表结构，生产环境建议设为false，手动迁移
+    auto-migrate: false
 
 # captcha configuration
 captcha:

--- a/server/config/system.go
+++ b/server/config/system.go
@@ -11,4 +11,5 @@ type System struct {
 	UseRedis      bool   `mapstructure:"use-redis" json:"use-redis" yaml:"use-redis"`                   // 使用redis
 	UseMongo      bool   `mapstructure:"use-mongo" json:"use-mongo" yaml:"use-mongo"`                   // 使用mongo
 	UseStrictAuth bool   `mapstructure:"use-strict-auth" json:"use-strict-auth" yaml:"use-strict-auth"` // 使用树形角色分配模式
+	AutoMigrate   bool   `mapstructure:"auto-migrate" json:"auto-migrate" yaml:"auto-migrate"`          // 自动迁移数据库表结构，生产环境建议设为false，手动迁移
 }

--- a/server/initialize/gorm.go
+++ b/server/initialize/gorm.go
@@ -35,6 +35,11 @@ func Gorm() *gorm.DB {
 }
 
 func RegisterTables() {
+	if !global.GVA_CONFIG.System.AutoMigrate {
+		global.GVA_LOG.Info("auto-migrate is disabled, skipping table registration")
+		return
+	}
+
 	db := global.GVA_DB
 	err := db.AutoMigrate(
 


### PR DESCRIPTION
增加自动迁移autoMigrate开关配置
生产环境可以禁止自动迁移,使用更安全的手动确认
开发环境在数据库没有变动的情况下禁止自动迁移也可以加速启动