### PR TITLE
修复字典值分页bug

### DIFF
--- a/server/service/system/sys_dictionary_detail.go
+++ b/server/service/system/sys_dictionary_detail.go
@@ -83,7 +83,7 @@ func (dictionaryDetailService *DictionaryDetailService) GetSysDictionaryDetailIn
 	if err != nil {
 		return
 	}
-	err = db.Limit(limit).Offset(offset).Order("sort").Find(&sysDictionaryDetails).Error
+	err = db.Limit(limit).Offset(offset).Order("sort").Order("id").Find(&sysDictionaryDetails).Error
 	return sysDictionaryDetails, total, err
 }
 


### PR DESCRIPTION
当字典值有多页，且sort值一样时，分页返回的数据有问题，导致有些数据一直加载不出来