### PR TITLE
fix(jwt):修正令牌过期时间计算错误

### DIFF
--- a/server/middleware/jwt.go
+++ b/server/middleware/jwt.go
@@ -2,11 +2,12 @@ package middleware
 
 import (
 	"errors"
+	"strconv"
+	"time"
+
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/utils"
 	"github.com/golang-jwt/jwt/v5"
-	"strconv"
-	"time"
 
 	"github.com/flipped-aurora/gin-vue-admin/server/model/common/response"
 	"github.com/gin-gonic/gin"
@@ -59,7 +60,7 @@ func JWTAuth() gin.HandlerFunc {
 			newClaims, _ := j.ParseToken(newToken)
 			c.Header("new-token", newToken)
 			c.Header("new-expires-at", strconv.FormatInt(newClaims.ExpiresAt.Unix(), 10))
-			utils.SetToken(c, newToken, int(dr.Seconds()))
+			utils.SetToken(c, newToken, int(dr.Seconds()/60))
 			if global.GVA_CONFIG.System.UseMultipoint {
 				// 记录新的活跃jwt
 				_ = utils.SetRedisJWT(newToken, newClaims.Username)


### PR DESCRIPTION
- 调整了SetToken函数中的过期时间单位，从秒转换为分钟
- 确保新令牌的过期时间与配置保持一致- 修复了因时间单位不匹配导致的令牌提前失效问题
- 和 GetToken中保持一致

```go
func GetToken(c *gin.Context) string {
	token := c.Request.Header.Get("x-token")
	if token == "" {
		j := NewJWT()
		token, _ = c.Cookie("x-token")
		claims, err := j.ParseToken(token)
		if err != nil {
			global.GVA_LOG.Error("重新写入cookie token失败,未能成功解析token,请检查请求头是否存在x-token且claims是否为规定结构")
			return token
		}
		SetToken(c, token, int((claims.ExpiresAt.Unix()-time.Now().Unix())/60))
	}
	return token
}
```
