### PR TITLE
fix: correct cookie maxAge using seconds instead of minutes

### DIFF
--- a/server/api/v1/system/sys_user.go
+++ b/server/api/v1/system/sys_user.go
@@ -264,7 +264,7 @@ func (b *BaseApi) SetUserAuthority(c *gin.Context) {
 	}
 	c.Header("new-token", token)
 	c.Header("new-expires-at", strconv.FormatInt(claims.ExpiresAt.Unix(), 10))
-	utils.SetToken(c, token, int((claims.ExpiresAt.Unix()-time.Now().Unix())/60))
+	utils.SetToken(c, token, int(claims.ExpiresAt.Unix()-time.Now().Unix()))
 	response.OkWithMessage("修改成功", c)
 }
 

--- a/server/utils/claims.go
+++ b/server/utils/claims.go
@@ -49,7 +49,7 @@ func GetToken(c *gin.Context) string {
 			global.GVA_LOG.Error("重新写入cookie token失败,未能成功解析token,请检查请求头是否存在x-token且claims是否为规定结构")
 			return token
 		}
-		SetToken(c, token, int((claims.ExpiresAt.Unix()-time.Now().Unix())/60))
+		SetToken(c, token, int(claims.ExpiresAt.Unix()-time.Now().Unix()))
 	}
 	return token
 }


### PR DESCRIPTION
cookie单位是秒
有两处错误/60导致有效期被缩短了60倍,频繁触发过期

The SetToken function expects maxAge in seconds (standard for HTTP cookies), but the code was incorrectly dividing by 60, causing cookies to expire 60 times faster than intended.