### PR TITLE
fix: repeat alter gorm autoMigrate due to incorrect comments

### DIFF
--- a/server/model/system/sys_base_menu.go
+++ b/server/model/system/sys_base_menu.go
@@ -13,7 +13,7 @@ type SysBaseMenu struct {
 	Hidden        bool                   `json:"hidden" gorm:"comment:是否在列表隐藏"`      // 是否在列表隐藏
 	Component     string                 `json:"component" gorm:"comment:对应前端文件路径"` // 对应前端文件路径
 	Sort          int                    `json:"sort" gorm:"comment:排序标记"`              // 排序标记
-	Meta          `json:"meta" gorm:"embedded;comment:附加属性"`                            // 附加属性
+	Meta          `json:"meta" gorm:"embedded"`                                             // 附加属性
 	SysAuthoritys []SysAuthority         `json:"authoritys" gorm:"many2many:sys_authority_menus;"`
 	Children      []SysBaseMenu          `json:"children" gorm:"-"`
 	Parameters    []SysBaseMenuParameter `json:"parameters"`


### PR DESCRIPTION
gorm的autoMigrate会将embedded的注释`附加属性`同步到mysql
但每次比较又是根据实际字段的注释
造成每次autoMigrate都会重复执行一次alter修改字段