### PR TITLE
bugfix:用户管理界面无法分配 / 查看角色

### DIFF
--- a/web/src/view/superAdmin/user/user.vue
+++ b/web/src/view/superAdmin/user/user.vue
@@ -174,7 +174,7 @@
         </div>
       </template>
     </el-dialog>
-    
+
     <el-drawer
       v-model="addUserDialog"
       :size="appStore.drawerSize"
@@ -356,6 +356,12 @@
     }
   )
 
+  const authOptions = ref([])
+  const setOptions = (authData) => {
+    authOptions.value = []
+    setAuthorityOptions(authData, authOptions.value)
+  }
+
   const initPage = async () => {
     getTableData()
     const res = await getAuthorityList()
@@ -373,7 +379,7 @@
     nickName: '',
     password: ''
   })
-  
+
   // 生成随机密码
   const generateRandomPassword = () => {
     const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*'
@@ -395,7 +401,7 @@
       })
     })
   }
-  
+
   // 打开重置密码对话框
   const resetPasswordFunc = (row) => {
     resetPwdInfo.value.ID = row.ID
@@ -404,7 +410,7 @@
     resetPwdInfo.value.password = ''
     resetPwdDialog.value = true
   }
-  
+
   // 确认重置密码
   const confirmResetPassword = async () => {
     if (!resetPwdInfo.value.password) {
@@ -414,12 +420,12 @@
       })
       return
     }
-    
+
     const res = await resetPassword({
       ID: resetPwdInfo.value.ID,
       password: resetPwdInfo.value.password
     })
-    
+
     if (res.code === 0) {
       ElMessage({
         type: 'success',
@@ -433,7 +439,7 @@
       })
     }
   }
-  
+
   // 关闭重置密码对话框
   const closeResetPwdDialog = () => {
     resetPwdInfo.value.password = ''
@@ -448,12 +454,6 @@
             return i.authorityId
           })
       })
-  }
-
-  const authOptions = ref([])
-  const setOptions = (authData) => {
-    authOptions.value = []
-    setAuthorityOptions(authData, authOptions.value)
   }
 
   const deleteUserFunc = async (row) => {


### PR DESCRIPTION
实测线上生产环境会报错, 本地生产环境不会

vite build编译时压缩代码 / 优化, 如果不更改会报错

线上报错日志
VM3799 user.DWwFdK0l.js:4  Uncaught (in promise) ReferenceError: Cannot access 'ee' before initialization
    at VM3799 user.DWwFdK0l.js:4:1706
    at setup (VM3799 user.DWwFdK0l.js:4:1728)
    at ys (vue.runtime.esm-bundler.CZzCD5CJ.js:10:29982)
    at vue.runtime.esm-bundler.CZzCD5CJ.js:10:75977
    at ra (vue.runtime.esm-bundler.CZzCD5CJ.js:10:76157)
    at L (vue.runtime.esm-bundler.CZzCD5CJ.js:10:56161)
    at M (vue.runtime.esm-bundler.CZzCD5CJ.js:10:56055)
    at y (vue.runtime.esm-bundler.CZzCD5CJ.js:10:53105)
    at et.l [as fn] (vue.runtime.esm-bundler.CZzCD5CJ.js:10:57178)
    at et.run (vue.runtime.esm-bundler.CZzCD5CJ.js:10:23596)
<img width="1122" height="450" alt="70f7a8a1029a48378d48d91be95c270b" src="https://github.com/user-attachments/assets/657a8105-247a-4f56-9341-e97ffcae970d" />

线上报错js文件
点击报错跳转在116行代码处
[报错.js](https://github.com/user-attachments/files/23420111/default.js)

BUG效果无法发送获取角色列表的请求, 导致数据为空无法分配角色
<img width="271" height="384" alt="e6d4aa70b6de00ed99edc1f061f6478b" src="https://github.com/user-attachments/assets/72d040af-c077-4939-a1e6-db2cb13cf52d" />

