### PR TITLE
用户管理的侧边栏优化体验

### DIFF
--- a/web/src/view/superAdmin/user/user.vue
+++ b/web/src/view/superAdmin/user/user.vue
@@ -179,8 +179,6 @@
       v-model="addUserDialog"
       :size="appStore.drawerSize"
       :show-close="false"
-      :close-on-press-escape="false"
-      :close-on-click-modal="false"
     >
       <template #header>
         <div class="flex justify-between items-center">


### PR DESCRIPTION
其他页面都可以通过点击外层关闭侧边栏，用户界面不可以，养成习惯后体验不太好，故允许点击外层关闭侧边栏