### PR TITLE
MD5 碰撞可能导致不同内容被误判为同一文件

### DIFF
--- a/server/service/example/exa_breakpoint_continue.go
+++ b/server/service/example/exa_breakpoint_continue.go
@@ -24,7 +24,7 @@ func (e *FileUploadAndDownloadService) FindOrCreateFile(fileMd5 string, fileName
 	cfile.FileName = fileName
 	cfile.ChunkTotal = chunkTotal
 
-	if errors.Is(global.GVA_DB.Where("file_md5 = ? AND is_finish = ?", fileMd5, true).First(&file).Error, gorm.ErrRecordNotFound) {
+	if errors.Is(global.GVA_DB.Where("file_md5 = ? AND file_name = ? AND is_finish = ?", fileMd5, fileName, true).First(&file).Error, gorm.ErrRecordNotFound) {
 		err = global.GVA_DB.Where("file_md5 = ? AND file_name = ?", fileMd5, fileName).Preload("ExaFileChunk").FirstOrCreate(&file, cfile).Error
 		return file, err
 	}


### PR DESCRIPTION
	// 检查是否存在已完成上传的文件（is_finish = true）
	// 同时使用 fileMd5 和 fileName 作为查询条件，确保文件唯一性
	// 原因：虽然 MD5 碰撞概率极低，但理论上仍可能发生（不同内容产生相同 MD5）
	// 同时使用 MD5 和文件名可以避免误匹配到错误的文件
	// 使用 errors.Is 判断是否为记录不存在的错误，这是 GORM 的标准做法
	// 好处：可以区分"记录不存在"和"其他数据库错误"，逻辑更清晰