### PR TITLE
文件句柄泄露问题

### DIFF
--- a/server/utils/breakpoint_continue.go
+++ b/server/utils/breakpoint_continue.go
@@ -62,13 +62,13 @@ func makeFileContent(content []byte, fileName string, FileDir string, contentNum
 	f, err := os.Create(path)
 	if err != nil {
 		return path, err
-	} else {
-		_, err = f.Write(content)
-		if err != nil {
-			return path, err
-		}
 	}
 	defer f.Close()
+	_, err = f.Write(content)
+	if err != nil {
+		return path, err
+	}
+
 	return path, nil
 }
 


### PR DESCRIPTION
问题分析：
原代码中，如果 os.Create 成功但 f.Write 失败，函数会在第170行直接返回
此时 defer f.Close() 还未注册（在第177行），文件句柄不会被关闭，导致资源泄漏
修复方案：
将 defer f.Close() 移到 os.Create 成功后立即注册
这样无论后续 f.Write 是否成功，文件都会被正确关闭