### PR TITLE
fix: 修复参数管理中使用参数键查询错误问题

### DIFF
--- a/server/service/system/sys_params.go
+++ b/server/service/system/sys_params.go
@@ -59,7 +59,7 @@ func (sysParamsService *SysParamsService) GetSysParamsInfoList(info systemReq.Sy
 		db = db.Where("name LIKE ?", "%"+info.Name+"%")
 	}
 	if info.Key != "" {
-		db = db.Where("key LIKE ?", "%"+info.Key+"%")
+		db = db.Where("'key' LIKE ?", "%"+info.Key+"%")
 	}
 	err = db.Count(&total).Error
 	if err != nil {


### PR DESCRIPTION
问题描述：

【超级管理员】-【参数管理】中使用【参数键】作为查询条件报错：
<img width="1530" height="231" alt="image" src="https://github.com/user-attachments/assets/58368dcc-aec1-4269-9e85-dbbeaac8e245" />

```sql
Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'key LIKE ? AND `sys_params`.`deleted_at` IS NULL' at line 1
```

运行环境：
win11
mysql 8.4.6

修复方案：
server/service/system/sys_params.go:62
查询条件中的字符串key用单引号包裹