### PR TITLE
feat: 添加 vite-check-multiple-dom 插件，支持路由多根检测

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -79,6 +79,7 @@
     "sass": "^1.78.0",
     "terser": "^5.31.6",
     "vite": "^6.2.3",
+    "vite-check-multiple-dom": "0.2.1",
     "vite-plugin-banner": "^0.8.0",
     "vite-plugin-importer": "^0.2.5",
     "vite-plugin-vue-devtools": "^7.0.16"

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -3,6 +3,7 @@ import 'element-plus/theme-chalk/dark/css-vars.css'
 import 'uno.css'
 import { createApp } from 'vue'
 import ElementPlus from 'element-plus'
+import { setupVueRootValidator } from 'vite-check-multiple-dom/client';
 
 import 'element-plus/dist/index.css'
 // 引入gin-vue-admin前端初始化相关内容
@@ -20,6 +21,10 @@ import '@/core/error-handel'
 const app = createApp(App)
 
 app.config.productionTip = false
+
+setupVueRootValidator(app, {
+    lang: 'zh'
+  })
 
 app
   .use(run)

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -8,6 +8,7 @@ import vuePlugin from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 import VueFilePathPlugin from './vitePlugin/componentName/index.js'
 import { svgBuilder } from 'vite-auto-import-svg'
+import vueRootValidator from 'vite-check-multiple-dom';
 import { AddSecret } from './vitePlugin/secret'
 import UnoCSS from '@unocss/vite'
 
@@ -79,7 +80,7 @@ export default ({ mode }) => {
           rewrite: (path) =>
             path.replace(new RegExp('^' + process.env.VITE_BASE_API), '')
         },
-         "/plugin": {
+        "/plugin": {
           // 需要代理的路径   例如 '/api'
           target: `https://plugin.gin-vue-admin.com/api/`, // 代理到 目标路径
           changeOrigin: true,
@@ -118,10 +119,11 @@ export default ({ mode }) => {
         ]
       }),
       vuePlugin(),
-      svgBuilder(['./src/plugin/','./src/assets/icons/'],base, outDir,'assets', NODE_ENV),
+      svgBuilder(['./src/plugin/', './src/assets/icons/'], base, outDir, 'assets', NODE_ENV),
       [Banner(`\n Build based on gin-vue-admin \n Time : ${timestamp}`)],
       VueFilePathPlugin('./src/pathInfo.json'),
-      UnoCSS()
+      UnoCSS(),
+      vueRootValidator()
     ]
   }
   return config


### PR DESCRIPTION
在出现多根情况的时候，可以直接拦截并且在页面上强提示，该插件仅在开发模式生效

<img width="1397" height="636" alt="image" src="https://github.com/user-attachments/assets/828a34c4-959e-40bd-a1c1-78dcd135a060" />
