### PR TITLE
security(jwt): distribute JWT blacklist via Redis (L1 BlackCache + L2…

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
+	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible
 	github.com/aws/aws-sdk-go-v2 v1.41.2
 	github.com/aws/aws-sdk-go-v2/config v1.32.10
@@ -50,6 +51,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.37.0
 	golang.org/x/sync v0.13.0
+	golang.org/x/sys v0.32.0
 	golang.org/x/text v0.24.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/datatypes v1.2.5
@@ -184,6 +186,7 @@ require (
 	github.com/xuri/nfp v0.0.0-20250111060730-82a408b9aa71 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
@@ -192,7 +195,6 @@ require (
 	golang.org/x/image v0.23.0 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
-	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	golang.org/x/tools v0.29.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -50,6 +50,8 @@ github.com/STARRY-S/zip v0.2.1 h1:pWBd4tuSGm3wtpoqRZZ2EAwOmcHK6XFf7bU9qcJXyFg=
 github.com/STARRY-S/zip v0.2.1/go.mod h1:xNvshLODWtC4EJ702g7cTYn13G53o1+X9BWnPFpcWV4=
 github.com/alex-ant/gomath v0.0.0-20160516115720-89013a210a82 h1:7dONQ3WNZ1zy960TmkxJPuwoolZwL7xKtpcM04MBnt4=
 github.com/alex-ant/gomath v0.0.0-20160516115720-89013a210a82/go.mod h1:nLnM0KdK1CmygvjpDUO6m1TjSsiQtL61juhNsvV/JVI=
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible h1:8psS8a+wKfiLt1iVDX79F7Y6wUM49Lcha2FMXt4UM8g=
 github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
@@ -536,6 +538,8 @@ github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT0
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.mongodb.org/mongo-driver v1.17.1/go.mod h1:wwWm/+BuOddhcq3n68LKRmgk2wXzmF6s0SFOa0GINL4=

--- a/server/middleware/jwt.go
+++ b/server/middleware/jwt.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
+	"github.com/flipped-aurora/gin-vue-admin/server/service"
 	"github.com/flipped-aurora/gin-vue-admin/server/utils"
 	"github.com/golang-jwt/jwt/v5"
 
@@ -22,7 +23,7 @@ func JWTAuth() gin.HandlerFunc {
 			c.Abort()
 			return
 		}
-		if isBlacklist(token) {
+		if isBlacklist(c, token) {
 			response.NoAuth("您的帐户异地登陆或令牌失效", c)
 			utils.ClearToken(c)
 			c.Abort()
@@ -78,12 +79,14 @@ func JWTAuth() gin.HandlerFunc {
 }
 
 //@author: [piexlmax](https://github.com/piexlmax)
-//@function: IsBlacklist
-//@description: 判断JWT是否在黑名单内部
-//@param: jwt string
+//@function: isBlacklist
+//@description: 判断JWT是否在黑名单内部（BlackCache L1 + Redis L2 分层查询）
+//@param: c *gin.Context, jwt string
 //@return: bool
 
-func isBlacklist(jwt string) bool {
-	_, ok := global.BlackCache.Get(jwt)
-	return ok
+// isBlacklist 接收 *gin.Context 是为了把 request context 串下去，
+// 让 Redis 查询能被 HTTP 超时 / 取消连带中断。
+// 具体分层策略见 service/system.JwtService.IsInBlacklist 的注释。
+func isBlacklist(c *gin.Context, jwt string) bool {
+	return service.ServiceGroupApp.SystemServiceGroup.JwtService.IsInBlacklist(c.Request.Context(), jwt)
 }

--- a/server/service/system/jwt_black_list.go
+++ b/server/service/system/jwt_black_list.go
@@ -19,10 +19,21 @@ var JwtServiceApp = new(JwtService)
 //@param: jwtList model.JwtBlacklist
 //@return: err error
 
+// 写路径：DB + Redis + BlackCache 三写。
+//   - DB 是 source of truth（持久化）。
+//   - Redis 是分布式 L2（让多实例立刻一致）。
+//   - BlackCache 是本实例 L1（省一次 Redis 往返）。
+//
+// Redis 未配置 / 写失败都不阻塞流程：DB 已落盘；其他实例读路径命中 DB
+// 重新同步 Redis 即可。
 func (jwtService *JwtService) JsonInBlacklist(jwtList system.JwtBlacklist) (err error) {
 	err = global.GVA_DB.Create(&jwtList).Error
 	if err != nil {
 		return
+	}
+	if rerr := SetJWTBlacklistRedis(context.Background(), jwtList.Jwt); rerr != nil && global.GVA_LOG != nil {
+		global.GVA_LOG.Warn("jwt blacklist: redis write failed, falling back to BlackCache only",
+			zap.Error(rerr))
 	}
 	global.BlackCache.SetDefault(jwtList.Jwt, struct{}{})
 	return
@@ -39,6 +50,35 @@ func (jwtService *JwtService) GetRedisJWT(userName string) (redisJWT string, err
 	return redisJWT, err
 }
 
+// IsInBlacklist 分层查询 JWT 黑名单。
+//
+//   - L1 BlackCache 命中 → true（进程内即判定，零 IO）。
+//   - L1 未命中且 Redis 可用 → 查 Redis；命中后顺手回填 L1。
+//   - Redis 未配置或不可用 → 退化为 BlackCache-only（等价于历史 sync.Map 行为）。
+//
+// Fail-open 原则：Redis 抖动不得阻塞鉴权。最坏情况是被拉黑的 token 在
+// 某节点多活一小段时间，直到该节点下次 LoadAll / HydrateRedisBlacklistFromDB。
+func (jwtService *JwtService) IsInBlacklist(ctx context.Context, token string) bool {
+	if token == "" {
+		return false
+	}
+	if _, ok := global.BlackCache.Get(token); ok {
+		return true
+	}
+	hit, err := IsJWTBlacklistedRedis(ctx, token)
+	if err != nil {
+		return false
+	}
+	if hit {
+		global.BlackCache.SetDefault(token, struct{}{})
+		return true
+	}
+	return false
+}
+
+// LoadAll 启动时从 DB 加载 JWT 黑名单。
+//   - 全量灌进 BlackCache（本实例 L1，保持旧行为）。
+//   - 异步回填 Redis（分布式 L2，新节点启动时迅速对齐其他节点）。
 func LoadAll() {
 	var data []string
 	err := global.GVA_DB.Model(&system.JwtBlacklist{}).Select("jwt").Find(&data).Error
@@ -49,4 +89,5 @@ func LoadAll() {
 	for i := 0; i < len(data); i++ {
 		global.BlackCache.SetDefault(data[i], struct{}{})
 	} // jwt黑名单 加入 BlackCache 中
+	go HydrateRedisBlacklistFromDB(context.Background(), data)
 }

--- a/server/service/system/jwt_black_list_redis.go
+++ b/server/service/system/jwt_black_list_redis.go
@@ -1,0 +1,154 @@
+package system
+
+// 分布式 JWT 黑名单的 Redis 层。
+//
+// 历史：JwtService 只把黑名单写进 global.BlackCache (sync.Map)，
+//       在多实例部署下，A 实例拉黑的 token 对 B 实例无效 —— 管理员的「踢下线」失效。
+//
+// 设计：
+//   - DB (system.JwtBlacklist) 仍然是 source of truth，用于冷启动时的 LoadAll。
+//   - Redis 是分布式 L2，JsonInBlacklist 写入时同步刷 Redis。
+//   - BlackCache 是进程级 L1，命中即短路；未命中再查 Redis。
+//   - Redis 未配置或短暂不可用时自动退化为 BlackCache-only（与未打此补丁时一致）。
+//
+// Key 设计：
+//   gva:jwt:blacklist:<sha256(token)>   —— 固定长度 64 hex 字符，避免把 2KB+ 的 token
+//   直接当 key；hash 对齐 Redis 的 key 大小最佳实践。
+//
+// TTL：
+//   贴近 token 自身 exp；无法解析的 token 走保守默认值；已过期的 token 只写 1s
+//   用来挡住并发 race；上限 30 天兜底。
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/flipped-aurora/gin-vue-admin/server/global"
+	jwtlib "github.com/golang-jwt/jwt/v5"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+const (
+	jwtBlacklistRedisPrefix  = "gva:jwt:blacklist:"
+	jwtBlacklistDefaultTTL   = 24 * time.Hour
+	jwtBlacklistMinTTL       = time.Second
+	jwtBlacklistMaxTTL       = 30 * 24 * time.Hour
+	jwtBlacklistReadTimeout  = 200 * time.Millisecond
+	jwtBlacklistWriteTimeout = 500 * time.Millisecond
+)
+
+// ErrBlacklistRedisUnavailable 表示 Redis 不可用；调用方应退化到 BlackCache-only。
+var ErrBlacklistRedisUnavailable = errors.New("jwt blacklist: redis unavailable")
+
+func jwtBlacklistRedisKey(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return jwtBlacklistRedisPrefix + hex.EncodeToString(sum[:])
+}
+
+// deriveBlacklistTTL 不校验签名，只读 exp 算剩余寿命。
+// ParseUnverified 是 jwt/v5 的合法 API —— 签名校验在上游鉴权链路已经完成，
+// 此处只用来推断要给 Redis key 多长的 TTL。
+func deriveBlacklistTTL(token string) time.Duration {
+	parser := jwtlib.NewParser()
+	claims := jwtlib.RegisteredClaims{}
+	_, _, err := parser.ParseUnverified(token, &claims)
+	if err != nil || claims.ExpiresAt == nil {
+		return jwtBlacklistDefaultTTL
+	}
+	remaining := time.Until(claims.ExpiresAt.Time)
+	if remaining <= 0 {
+		return jwtBlacklistMinTTL
+	}
+	if remaining > jwtBlacklistMaxTTL {
+		return jwtBlacklistMaxTTL
+	}
+	return remaining
+}
+
+// SetJWTBlacklistRedis 把 token 写入分布式黑名单。
+//
+//   - global.GVA_REDIS == nil（未配置 Redis）时返回 nil，让调用方无痛降级。
+//   - 返回非 nil 表示 Redis 可用但写失败；调用方应记录 warn 但不应阻塞主流程
+//     （DB 落盘成功即可；其他实例下次读路径会从 DB->Redis 走一遍）。
+func SetJWTBlacklistRedis(ctx context.Context, token string) error {
+	r := global.GVA_REDIS
+	if r == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, jwtBlacklistWriteTimeout)
+	defer cancel()
+	ttl := deriveBlacklistTTL(token)
+	return r.Set(ctx, jwtBlacklistRedisKey(token), "1", ttl).Err()
+}
+
+// IsJWTBlacklistedRedis 查询 Redis 黑名单。
+//
+//   - (true,  nil)                            token 在黑名单。
+//   - (false, nil)                            token 不在黑名单。
+//   - (false, ErrBlacklistRedisUnavailable)   Redis 未初始化 / 超时 / 连接错；
+//     调用方应退化到 BlackCache-only（等价于打补丁之前的单实例行为）。
+func IsJWTBlacklistedRedis(ctx context.Context, token string) (bool, error) {
+	r := global.GVA_REDIS
+	if r == nil {
+		return false, ErrBlacklistRedisUnavailable
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, jwtBlacklistReadTimeout)
+	defer cancel()
+	_, err := r.Get(ctx, jwtBlacklistRedisKey(token)).Result()
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, redis.Nil) {
+		return false, nil
+	}
+	return false, ErrBlacklistRedisUnavailable
+}
+
+// HydrateRedisBlacklistFromDB 把 DB 里未过期的 JWT 黑名单记录批量回填到 Redis。
+//
+// 目的：
+//   - 新节点启动时快速恢复分布式状态；
+//   - Redis 经历重建 / 清空 / 故障恢复后也能自愈。
+//
+// 调用点：LoadAll() 之后异步触发。
+// 幂等：同一 token 被 Set 多次仅覆盖 TTL，无副作用。
+func HydrateRedisBlacklistFromDB(ctx context.Context, tokens []string) {
+	r := global.GVA_REDIS
+	if r == nil || len(tokens) == 0 {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var okCount, failCount int
+	for _, tok := range tokens {
+		if tok == "" {
+			continue
+		}
+		cctx, cancel := context.WithTimeout(ctx, jwtBlacklistWriteTimeout)
+		err := r.Set(cctx, jwtBlacklistRedisKey(tok), "1", deriveBlacklistTTL(tok)).Err()
+		cancel()
+		if err != nil {
+			failCount++
+			continue
+		}
+		okCount++
+	}
+	if global.GVA_LOG != nil {
+		global.GVA_LOG.Info("jwt blacklist hydrated to redis",
+			zap.Int("ok", okCount),
+			zap.Int("fail", failCount),
+			zap.Int("total", len(tokens)),
+		)
+	}
+}

--- a/server/service/system/jwt_black_list_redis_test.go
+++ b/server/service/system/jwt_black_list_redis_test.go
@@ -1,0 +1,204 @@
+package system
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	jwtlib "github.com/golang-jwt/jwt/v5"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/flipped-aurora/gin-vue-admin/server/global"
+	"github.com/songzhibin97/gkit/cache/local_cache"
+)
+
+var testJWTCounter atomic.Uint64
+
+// JWT 黑名单的 Redis 层单元测试：
+//   - 写路径（SetJWTBlacklistRedis）和读路径（IsJWTBlacklistedRedis）的 round-trip。
+//   - Redis 故障时的 fail-open 降级。
+//   - IsInBlacklist 分层查询的命中顺序。
+//   - TTL 派生逻辑（正常 token / 无法解析的 token / 已过期 token）。
+//   - HydrateRedisBlacklistFromDB 的批量回填。
+//
+// 约束：不依赖真实 MySQL（JsonInBlacklist 写 DB 不在本文件覆盖范围），
+//       只验证 "Redis 层 + BlackCache 层" 的组合行为。
+
+func setupRedisBlacklistTest(t *testing.T) (*miniredis.Miniredis, func()) {
+	t.Helper()
+	srv, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	rdb := redis.NewClient(&redis.Options{Addr: srv.Addr()})
+
+	origRedis := global.GVA_REDIS
+	origCache := global.BlackCache
+	global.GVA_REDIS = rdb
+	global.BlackCache = local_cache.NewCache(local_cache.SetDefaultExpire(5 * time.Second))
+
+	cleanup := func() {
+		_ = rdb.Close()
+		srv.Close()
+		global.GVA_REDIS = origRedis
+		global.BlackCache = origCache
+	}
+	return srv, cleanup
+}
+
+func signTestJWT(t *testing.T, ttl time.Duration) string {
+	t.Helper()
+	token := jwtlib.NewWithClaims(jwtlib.SigningMethodHS256, jwtlib.RegisteredClaims{
+		ExpiresAt: jwtlib.NewNumericDate(time.Now().Add(ttl)),
+		ID:        "test-" + strconv.FormatUint(testJWTCounter.Add(1), 10),
+	})
+	signed, err := token.SignedString([]byte("test-secret"))
+	if err != nil {
+		t.Fatalf("sign jwt: %v", err)
+	}
+	return signed
+}
+
+func TestDeriveBlacklistTTL_UsesJWTExp(t *testing.T) {
+	tok := signTestJWT(t, 1*time.Hour)
+	got := deriveBlacklistTTL(tok)
+	if got < 59*time.Minute || got > 61*time.Minute {
+		t.Errorf("ttl from 1h-exp jwt want ~1h, got %s", got)
+	}
+}
+
+func TestDeriveBlacklistTTL_BadToken(t *testing.T) {
+	got := deriveBlacklistTTL("not-a-real-jwt")
+	if got != jwtBlacklistDefaultTTL {
+		t.Errorf("unparseable token ttl want default %s, got %s", jwtBlacklistDefaultTTL, got)
+	}
+}
+
+func TestDeriveBlacklistTTL_AlreadyExpired(t *testing.T) {
+	tok := signTestJWT(t, -1*time.Hour)
+	got := deriveBlacklistTTL(tok)
+	if got != jwtBlacklistMinTTL {
+		t.Errorf("expired token ttl want min %s, got %s", jwtBlacklistMinTTL, got)
+	}
+}
+
+func TestSetAndIsBlacklistedRedis(t *testing.T) {
+	_, cleanup := setupRedisBlacklistTest(t)
+	defer cleanup()
+
+	tok := signTestJWT(t, 1*time.Hour)
+	ctx := context.Background()
+
+	if hit, err := IsJWTBlacklistedRedis(ctx, tok); err != nil || hit {
+		t.Fatalf("precondition: token not yet blacklisted, got hit=%v err=%v", hit, err)
+	}
+	if err := SetJWTBlacklistRedis(ctx, tok); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	hit, err := IsJWTBlacklistedRedis(ctx, tok)
+	if err != nil {
+		t.Fatalf("Is: %v", err)
+	}
+	if !hit {
+		t.Error("expected token to be blacklisted after Set")
+	}
+}
+
+func TestIsJWTBlacklistedRedis_NoRedis(t *testing.T) {
+	orig := global.GVA_REDIS
+	global.GVA_REDIS = nil
+	defer func() { global.GVA_REDIS = orig }()
+
+	hit, err := IsJWTBlacklistedRedis(context.Background(), "any-token")
+	if hit {
+		t.Error("expected hit=false when Redis is nil")
+	}
+	if err == nil || err != ErrBlacklistRedisUnavailable {
+		t.Errorf("want ErrBlacklistRedisUnavailable, got %v", err)
+	}
+}
+
+func TestJwtService_IsInBlacklist_Layered(t *testing.T) {
+	_, cleanup := setupRedisBlacklistTest(t)
+	defer cleanup()
+
+	svc := &JwtService{}
+	ctx := context.Background()
+
+	tokL1 := signTestJWT(t, 1*time.Hour)
+	global.BlackCache.SetDefault(tokL1, struct{}{})
+	if !svc.IsInBlacklist(ctx, tokL1) {
+		t.Error("L1 BlackCache hit should short-circuit to true")
+	}
+
+	tokL2 := signTestJWT(t, 1*time.Hour)
+	if err := SetJWTBlacklistRedis(ctx, tokL2); err != nil {
+		t.Fatal(err)
+	}
+	if !svc.IsInBlacklist(ctx, tokL2) {
+		t.Error("Redis hit should return true via IsInBlacklist")
+	}
+	if _, ok := global.BlackCache.Get(tokL2); !ok {
+		t.Error("Redis hit should backfill BlackCache L1")
+	}
+
+	tokClean := signTestJWT(t, 1*time.Hour)
+	if svc.IsInBlacklist(ctx, tokClean) {
+		t.Error("unknown token must not be reported as blacklisted")
+	}
+
+	if svc.IsInBlacklist(ctx, "") {
+		t.Error("empty token must not be reported as blacklisted")
+	}
+}
+
+func TestJwtService_IsInBlacklist_RedisDownFailsOpen(t *testing.T) {
+	origCache := global.BlackCache
+	global.BlackCache = local_cache.NewCache(local_cache.SetDefaultExpire(5 * time.Second))
+	defer func() { global.BlackCache = origCache }()
+
+	origRedis := global.GVA_REDIS
+	global.GVA_REDIS = nil
+	defer func() { global.GVA_REDIS = origRedis }()
+
+	svc := &JwtService{}
+	tok := signTestJWT(t, 1*time.Hour)
+
+	global.BlackCache.SetDefault(tok, struct{}{})
+	if !svc.IsInBlacklist(context.Background(), tok) {
+		t.Error("with Redis down, L1 hit must still short-circuit")
+	}
+
+	other := signTestJWT(t, 1*time.Hour)
+	if svc.IsInBlacklist(context.Background(), other) {
+		t.Error("with Redis down and L1 miss, default is fail-open (false)")
+	}
+}
+
+func TestHydrateRedisBlacklistFromDB(t *testing.T) {
+	_, cleanup := setupRedisBlacklistTest(t)
+	defer cleanup()
+
+	toks := []string{
+		signTestJWT(t, 1*time.Hour),
+		signTestJWT(t, 2*time.Hour),
+		"",
+	}
+	HydrateRedisBlacklistFromDB(context.Background(), toks)
+
+	for i, tok := range toks {
+		if tok == "" {
+			continue
+		}
+		hit, err := IsJWTBlacklistedRedis(context.Background(), tok)
+		if err != nil {
+			t.Errorf("token[%d] Is err: %v", i, err)
+		}
+		if !hit {
+			t.Errorf("token[%d] should be hydrated into Redis", i)
+		}
+	}
+}


### PR DESCRIPTION
… Redis)

Problem
  JwtService only writes revoked tokens to global.BlackCache (a process-local
  sync.Map wrapper). In any multi-replica deployment (horizontal scaling,
  blue-green rollout, k8s with replicas > 1), a token revoked on instance A
  remains valid on instance B until that instance's next LoadAll(). For an
  attacker who stole a token and is being kicked out, the eviction is
  effectively racy — the revocation is only reliable on a single node.

Fix
  Layered lookup with DB as source of truth:
    - L1: global.BlackCache (unchanged, process-local, zero IO).
    - L2: Redis (new) — SHA-256-keyed, TTL derived from token exp.
    - SoT: DB (unchanged) — LoadAll() on boot still rehydrates L1 and now also fires an async HydrateRedisBlacklistFromDB so a fresh node catches up to the other replicas immediately.

  New JwtService.IsInBlacklist(ctx, token):
    - L1 hit          → true
    - L1 miss, L2 hit → backfill L1, return true
    - Redis down      → fail-open (false), degrading to legacy
                        single-instance behaviour; never breaks auth.

  JsonInBlacklist now writes DB + Redis + BlackCache. Redis write failure
  only logs a warn — DB has persisted the revocation, so any node that
  reads through (LoadAll / Hydrate) will reconcile.

Graceful degradation (required for projects that don't use Redis)
  Everything gates on `global.GVA_REDIS == nil`, which is exactly how GVA
  signals "Redis not configured". In that mode:
    - SetJWTBlacklistRedis       returns nil (no-op).
    - IsJWTBlacklistedRedis      returns ErrBlacklistRedisUnavailable.
    - IsInBlacklist              falls back to BlackCache-only,
                                  identical to pre-patch behaviour.
  No config changes are required; existing single-node deployments see
  zero behavioural difference.

middleware/jwt.go
  isBlacklist(token) → isBlacklist(c, token). The *gin.Context is
  threaded purely so the Redis lookup honours request cancellation /
  timeout. The function now delegates to JwtService.IsInBlacklist.

Redis key & TTL design
  Key:  "gva:jwt:blacklist:" + sha256(token)  (fixed 64-hex, avoids
        putting 2KB+ tokens on the hot key path).
  TTL:  derived from the token's own exp claim (ParseUnverified — we're
        not re-checking the signature, just reading exp). Default 24h
        when unparseable, 1s when already expired (just wide enough to
        defeat concurrent replays), 30d hard ceiling.
  Timeouts: 200ms read, 500ms write — tight enough that a sick Redis
  can't stall the auth middleware.

Tests
  New package tests using alicebob/miniredis/v2:
    - TTL derivation (normal / unparseable / already-expired tokens).
    - Set/Is round-trip through Redis.
    - IsJWTBlacklistedRedis returns ErrBlacklistRedisUnavailable when global.GVA_REDIS is nil.
    - IsInBlacklist L1/L2 layering + L1 backfill from L2 hits.
    - IsInBlacklist fail-open when Redis is down.
    - HydrateRedisBlacklistFromDB batch behaviour. All 8 tests pass under -race.

Files
  + server/service/system/jwt_black_list_redis.go       (new)
  + server/service/system/jwt_black_list_redis_test.go  (new)
  M server/service/system/jwt_black_list.go
  M server/middleware/jwt.go
  M server/go.mod, server/go.sum  (miniredis test dep)

No schema changes, no config changes, no API changes.