### PR TITLE
[plugin/auto]: fix PostgreSQL compatibility for the new auto plugin

### DIFF
--- a/server/plugin/auto/initialize/menu.go
+++ b/server/plugin/auto/initialize/menu.go
@@ -107,7 +107,8 @@ func Menu(ctx context.Context) {
 			"component":    child.Component,
 			"sort":         child.Sort,
 			"hidden":       child.Hidden,
-			"meta":         child.Meta,
+			"title":        child.Meta.Title,
+			"icon":         child.Meta.Icon,
 			"keep_alive":   child.KeepAlive,
 			"default_menu": child.DefaultMenu,
 		})

--- a/server/plugin/auto/model/sys_ai_workflow_session.go
+++ b/server/plugin/auto/model/sys_ai_workflow_session.go
@@ -24,10 +24,10 @@ type SysAIWorkflowSession struct {
 	ConversationID string              `json:"conversationId" gorm:"column:conversation_id;size:255;comment:Dify会话ID"`
 	MessageID      string              `json:"messageId" gorm:"column:message_id;size:255;comment:Dify消息ID"`
 	CurrentNodeID  string              `json:"currentNodeId" gorm:"column:current_node_id;size:64;comment:当前选中节点ID"`
-	Settings       common.JSONMap      `json:"settings" gorm:"column:settings;type:longtext;comment:页面设置"`
-	FormData       common.JSONMap      `json:"formData" gorm:"column:form_data;type:longtext;comment:表单数据"`
-	ResultData     common.JSONMap      `json:"resultData" gorm:"column:result_data;type:longtext;comment:当前展示结果"`
-	Messages       []AIWorkflowMessage `json:"messages" gorm:"column:messages;serializer:json;type:longtext;comment:会话消息"`
+	Settings       common.JSONMap      `json:"settings" gorm:"column:settings;type:text;comment:页面设置"`
+	FormData       common.JSONMap      `json:"formData" gorm:"column:form_data;type:text;comment:表单数据"`
+	ResultData     common.JSONMap      `json:"resultData" gorm:"column:result_data;type:text;comment:当前展示结果"`
+	Messages       []AIWorkflowMessage `json:"messages" gorm:"column:messages;serializer:json;type:text;comment:会话消息"`
 }
 
 func (s *SysAIWorkflowSession) TableName() string {


### PR DESCRIPTION
## Summary

Two issues in the new `plugin/auto` (introduced by 6b8099ea) prevent it from booting on PostgreSQL. Both surface during `register auto plugin tables` on a fresh PG database.

### 1. `longtext` is MySQL-only

`SysAIWorkflowSession` uses `type:longtext` on four columns:

\`\`\`go
Settings   common.JSONMap      \`gorm:\"...;type:longtext;...\"\`
FormData   common.JSONMap      \`gorm:\"...;type:longtext;...\"\`
ResultData common.JSONMap      \`gorm:\"...;type:longtext;...\"\`
Messages   []AIWorkflowMessage \`gorm:\"...;type:longtext;...\"\`
\`\`\`

PostgreSQL has no `longtext` and panics:

\`\`\`
ERROR: type \"longtext\" does not exist (SQLSTATE 42704)
\`\`\`

Switched all four to `type:text`. `text` is unbounded on both PostgreSQL and MySQL, matches what other GVA models use for long strings (e.g. `gva_announcements_info.content`), and keeps semantics identical.

### 2. `Updates(map{\"meta\": child.Meta})` writes a non-existent column

`server/plugin/auto/initialize/menu.go:104` calls:

\`\`\`go
Updates(map[string]interface{}{
    ...
    \"meta\": child.Meta,
    ...
})
\`\`\`

But `Meta` is embedded via `gorm:\"embedded\"` in `model.SysBaseMenu` — there is no `meta` column. PostgreSQL fails with:

\`\`\`
ERROR: column \"meta\" of relation \"sys_base_menus\" does not exist (SQLSTATE 42703)
\`\`\`

(MySQL may silently drop it; either way the title/icon never get synced on existing rows.)

Replaced with explicit `title` and `icon` keys so the embedded columns are written correctly. `keep_alive` and `default_menu` were already explicit, so the fix only needs `title`/`icon`.

## Verified

- PostgreSQL 16 + fresh DB via init wizard: all three auto-plugin tables (`sys_ai_workflow_sessions`, `sys_auto_code_histories`, `sys_auto_code_packages`) create cleanly.
- 9 menu rows (`AutoRoot`, `AutoCode`, `AutoPkg`, `AIWorkflow`, `MCP`, `MCPTest`, `AutoInstallPlugin`, `Skills`, `AutoCodeAdmin`) inserted with correct titles and icons.
- Backend boot log no longer contains `register auto plugin tables failed`.

## Risk

Minimal. `text` is a strict superset of `longtext` semantics on the engines GVA supports; `title`/`icon` are existing columns being written through their proper names instead of the no-op `meta` key.