### PR TITLE
更新 Vite 版本

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -27,7 +27,6 @@
     "ace-builds": "^1.36.4",
     "axios": "1.8.2",
     "chokidar": "^4.0.0",
-    "core-js": "^3.38.1",
     "echarts": "5.5.1",
     "element-plus": "^2.13.6",
     "highlight.js": "^11.10.0",
@@ -61,8 +60,7 @@
     "@unocss/extractor-svelte": "^66.4.2",
     "@unocss/preset-wind3": "^66.4.2",
     "@unocss/vite": "^66.5.0",
-    "@vitejs/plugin-legacy": "^6.0.0",
-    "@vitejs/plugin-vue": "^5.0.3",
+    "@vitejs/plugin-vue": "^6.0.6",
     "@vue/cli-plugin-babel": "~5.0.8",
     "@vue/cli-plugin-eslint": "~5.0.8",
     "@vue/cli-plugin-router": "~5.0.8",
@@ -77,11 +75,10 @@
     "eslint-plugin-vue": "^9.19.2",
     "globals": "^16.3.0",
     "sass": "^1.78.0",
-    "terser": "^5.31.6",
-    "vite": "^6.2.3",
+    "vite": "^8.0.10",
     "vite-check-multiple-dom": "0.2.1",
     "vite-plugin-banner": "^0.8.0",
     "vite-plugin-importer": "^0.2.5",
-    "vite-plugin-vue-devtools": "^7.0.16"
+    "vite-plugin-vue-devtools": "^8.1.1"
   }
 }

--- a/web/src/view/person/person.vue
+++ b/web/src/view/person/person.vue
@@ -551,7 +551,7 @@
   ]
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
   .profile-container {
     @apply p-4 lg:p-6 min-h-screen bg-gray-50 dark:bg-slate-900;
 

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,4 +1,3 @@
-import legacyPlugin from '@vitejs/plugin-legacy'
 import { viteLogo } from './src/core/config'
 import Banner from 'vite-plugin-banner'
 import * as path from 'path'
@@ -19,21 +18,9 @@ export default ({ mode }) => {
 
   const timestamp = Date.parse(new Date())
 
-  const optimizeDeps = {}
-
   const alias = {
-    '@': path.resolve(__dirname, './src'),
+    '@': path.resolve(import.meta.dirname, './src'),
     vue$: 'vue/dist/vue.runtime.esm-bundler.js'
-  }
-
-  const esbuild = {}
-
-  const rollupOptions = {
-    output: {
-      entryFileNames: 'assets/087AC4D233B64EB0[name].[hash].js',
-      chunkFileNames: 'assets/087AC4D233B64EB0[name].[hash].js',
-      assetFileNames: 'assets/087AC4D233B64EB0[name].[hash].[ext]'
-    }
   }
 
   const base = '/'
@@ -78,34 +65,26 @@ export default ({ mode }) => {
       }
     },
     build: {
-      minify: 'terser', // 是否进行压缩,boolean | 'terser' | 'esbuild',默认使用terser
       manifest: false, // 是否产出manifest.json
       sourcemap: false, // 是否产出sourcemap.json
       outDir: outDir, // 产出目录
-      terserOptions: {
-        compress: {
-          //生产环境时移除console
-          drop_console: true,
-          drop_debugger: true
+      target: 'es2015',
+      rolldownOptions: {
+        output: {
+          minify: {
+            compress: {
+              dropConsole: true,   // 删除所有 console.*
+            }
+          },
+          entryFileNames: 'assets/087AC4D233B64EB0[name].[hash].js',
+          chunkFileNames: 'assets/087AC4D233B64EB0[name].[hash].js',
+          assetFileNames: 'assets/087AC4D233B64EB0[name].[hash].[ext]'
         }
-      },
-      rollupOptions
+      }
     },
-    esbuild,
-    optimizeDeps,
     plugins: [
       env.VITE_POSITION === 'open' &&
       vueDevTools({ launchEditor: env.VITE_EDITOR }),
-      legacyPlugin({
-        targets: [
-          'Android > 39',
-          'Chrome >= 60',
-          'Safari >= 10.1',
-          'iOS >= 10.3',
-          'Firefox >= 54',
-          'Edge >= 15'
-        ]
-      }),
       vuePlugin(),
       svgBuilder(['./src/plugin/', './src/assets/icons/'], base, outDir, 'assets', mode),
       [Banner(`\n Build based on gin-vue-admin \n Time : ${timestamp}`)],


### PR DESCRIPTION
更新 vite 至 vite8，默认打包器换为 rolldown，打包时间提升至 2s（macos26 m2 芯片），去除使用 @vitejs/plugin-legacy 里对于传统浏览器的支持，改为 rolldown 原生支持，现在支持最低的浏览器版本是：

- Chrome >=64
- Firefox >=67
- Safari >=11.1
- Edge >=79

Vite 需要 [Node.js](https://nodejs.org/en/) 版本 20.19+, 22.12+。然而，有些模板需要依赖更高的 Node 版本才能正常运行，当你的包管理器发出警告时，请注意升级你的 Node 版本。