### PR TITLE
fix: replace default JWT signing key with empty value

### DIFF
--- a/server/config.yaml
+++ b/server/config.yaml
@@ -2,10 +2,10 @@
 
 # jwt configuration
 jwt:
-    signing-key: qmPlus
+    signing-key: ""
     expires-time: 7d
     buffer-time: 1d
-    issuer: qmPlus
+    issuer: gin-vue-admin
 # zap logger configuration
 zap:
     level: info


### PR DESCRIPTION
## 问题

`server/config.yaml` 中 JWT 签名密钥默认为固定值：

```yaml
jwt:
    signing-key: qmPlus
```

**数据流：**

```
config.yaml (signing-key: qmPlus)
  -> config/jwt.go:4  SigningKey string
  -> utils/jwt.go:28  NewJWT() -> []byte(global.GVA_CONFIG.JWT.SigningKey)
  -> utils/jwt.go:49  CreateToken() 签名JWT
  -> middleware/jwt.go:33  ParseToken() 验证JWT
```

`qmPlus` 同时用于签发和验证所有 JWT token。虽然 `InitDB` 流程会通过 `uuid.New().String()` 自动替换密钥并 `WriteConfig()` 写回配置文件，但在初始化之前（或初始化失败时），任何人拿到源码都可以用 `qmPlus` 伪造任意用户 token。

## 修复

将默认值改为空字符串。`InitDB` 仍会生成随机 UUID 替换。