### PR TITLE
docs: mention MariaDB in README (zh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ swag init
 
 - 前端：用基于 [Vue](https://vuejs.org) 的 [Element](https://github.com/ElemeFE/element) 构建基础页面。
 - 后端：用 [Gin](https://gin-gonic.com/) 快速搭建基础restful风格API，[Gin](https://gin-gonic.com/) 是一个go语言编写的Web框架。
-- 数据库：采用`MySql` > (5.7) 版本 数据库引擎 InnoDB，使用 [gorm](http://gorm.cn) 实现对数据库的基本操作。
+- 数据库：采用 `MySQL` 或 `MariaDB`（5.7+），数据库引擎 InnoDB，使用 [gorm](http://gorm.cn) 实现对数据库的基本操作。
 - 缓存：使用`Redis`实现记录当前活跃用户的`jwt`令牌并实现多点登录限制。
 - API文档：使用`Swagger`构建自动化文档。
 - 配置文件：使用 [fsnotify](https://github.com/fsnotify/fsnotify) 和 [viper](https://github.com/spf13/viper) 实现`yaml`格式的配置文件。


### PR DESCRIPTION
## Summary

Updates the Chinese README tech-stack database line to mention MariaDB alongside MySQL (5.7+). The server already includes MariaDB version detection in `server/model/common/basetypes.go`; the README only listed MySQL.

Documentation only; no code or deployment changes.

## Test plan

- [x] README only