### PR TITLE
fix: respect SelectImage maxUpdateCount in media library

### DIFF
--- a/web/src/components/selectImage/selectImage.vue
+++ b/web/src/components/selectImage/selectImage.vue
@@ -23,7 +23,7 @@
           </div>
         </template>
       </draggable>
-      <selectComponent :rounded="rounded" v-if="model?.length < props.maxUpdateCount || props.maxUpdateCount === 0"
+      <selectComponent :rounded="rounded" v-if="currentImageCount < props.maxUpdateCount || props.maxUpdateCount === 0"
                        @chooseItem="openChooseImg" @deleteItem="openChooseImg"
       />
     </div>
@@ -149,7 +149,7 @@
 
 <script setup>
 import { getUrl, isVideoExt } from '@/utils/image'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { getFileList, editFileName, deleteFile } from '@/api/fileUploadAndDownload'
 import UploadImage from '@/components/upload/image.vue'
 import UploadCommon from '@/components/upload/common.vue'
@@ -286,6 +286,7 @@ const openChooseImg = async() => {
     model.value = ''
     return
   }
+  selectedImages.value = []
   await getImageList()
   await fetchCategories()
   drawer.value = true
@@ -419,6 +420,17 @@ const closeAddCategoryDialog = () => {
 
 const selectedImages = ref([])
 
+const currentImageCount = computed(() => {
+  if (Array.isArray(model.value)) {
+    return model.value.length
+  }
+  return model.value ? 1 : 0
+})
+
+const canSelectMoreImages = computed(() => {
+  return props.maxUpdateCount === 0 || currentImageCount.value + selectedImages.value.length < props.maxUpdateCount
+})
+
 const toggleImageSelection = (item) => {
   if (props.multiple === false) {
     chooseImg(item.url)
@@ -428,6 +440,13 @@ const toggleImageSelection = (item) => {
   if (index > -1) {
     selectedImages.value.splice(index, 1)
   } else {
+    if (!canSelectMoreImages.value) {
+      ElMessage({
+        type: 'warning',
+        message: `最多可选择${props.maxUpdateCount}个文件`
+      })
+      return
+    }
     selectedImages.value.push(item)
   }
 }
@@ -437,9 +456,17 @@ const isSelected = (item) => {
 }
 
 const useSelectedImages = () => {
-  selectedImages.value.forEach((item) => {
-    model.value.push(item.url)
-  })
+  if (!Array.isArray(model.value)) {
+    model.value = []
+  }
+  if (props.maxUpdateCount !== 0 && model.value.length + selectedImages.value.length > props.maxUpdateCount) {
+    ElMessage({
+      type: 'warning',
+      message: `最多可选择${props.maxUpdateCount}个文件`
+    })
+    return
+  }
+  model.value.push(...selectedImages.value.map(item => item.url))
   drawer.value = false
   selectedImages.value = []
 }


### PR DESCRIPTION
## Summary
- enforce `maxUpdateCount` while selecting images in the media library drawer
- add a final guard before appending selected media to the model
- reset stale drawer selections whenever the media library is opened

## Root cause
`maxUpdateCount` only controlled whether the outer add/select tile was shown. Once the media library drawer was open, users could select and confirm more files than the configured maximum.

## Validation
- `npm run build` in `web` passed
