### PR TITLE
refactor(web): 使用国际化函数为页面标题和面包屑添加多语言支持

### DIFF
--- a/web/src/utils/page.js
+++ b/web/src/utils/page.js
@@ -1,8 +1,9 @@
 import { fmtTitle } from '@/utils/fmtRouterTitle'
 import config from '@/core/config'
+import i18n from '@/i18n'
 export default function getPageTitle(pageTitle, route) {
   if (pageTitle) {
-    const title = fmtTitle(pageTitle, route)
+    const title = i18n.global.t(fmtTitle(pageTitle, route))
     return `${title} - ${config.appName}`
   }
   return `${config.appName}`

--- a/web/src/view/layout/header/index.vue
+++ b/web/src/view/layout/header/index.vue
@@ -40,7 +40,7 @@
           v-for="item in matched.slice(1, matched.length)"
           :key="item.path"
         >
-          {{ fmtTitle(item.meta.title, route) }}
+          {{ t(fmtTitle(item.meta.title, route)) }}
         </el-breadcrumb-item>
       </el-breadcrumb>
       <gva-aside


### PR DESCRIPTION
- 引入i18n模块以支持多语言翻译
- 在getPageTitle中使用i18n的t方法翻译格式化后的标题
- 在布局头部组件中将面包屑标题文本改为通过t方法翻译
- 保持原有标题格式和结构不变，增强国际化兼容性