### PR TITLE
fix: replace scan upload JWT with scoped one-time token

### DIFF
--- a/server/api/v1/example/exa_file_upload_download.go
+++ b/server/api/v1/example/exa_file_upload_download.go
@@ -1,17 +1,70 @@
 package example
 
 import (
+	"errors"
+	"strconv"
+
 	"github.com/flipped-aurora/gin-vue-admin/server/global"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/common/response"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/example"
 	"github.com/flipped-aurora/gin-vue-admin/server/model/example/request"
 	exampleRes "github.com/flipped-aurora/gin-vue-admin/server/model/example/response"
+	exampleService "github.com/flipped-aurora/gin-vue-admin/server/service/example"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
-	"strconv"
 )
 
 type FileUploadAndDownloadApi struct{}
+
+// CreateScanUploadToken 创建短时、一次性的扫码上传凭证
+// @Tags      ExaFileUploadAndDownload
+// @Summary   创建扫码上传凭证
+// @Security  ApiKeyAuth
+// @accept    application/json
+// @Produce   application/json
+// @Param     data  body      object{classId=int}  true  "文件分类 ID"
+// @Success   200   {object}  response.Response{data=object{token=string,expiresAt=int64},msg=string}
+// @Router    /fileUploadAndDownload/createScanUploadToken [post]
+func (b *FileUploadAndDownloadApi) CreateScanUploadToken(c *gin.Context) {
+	var req struct {
+		ClassID int `json:"classId"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil || req.ClassID < 0 {
+		response.FailWithMessage("classId 参数错误", c)
+		return
+	}
+	token, expiresAt, err := fileUploadAndDownloadService.IssueScanUploadToken(req.ClassID)
+	if err != nil {
+		global.GVA_LOG.Error("创建扫码上传凭证失败!", zap.Error(err))
+		response.FailWithMessage("创建扫码上传凭证失败", c)
+		return
+	}
+	response.OkWithDetailed(gin.H{
+		"token":     token,
+		"expiresAt": expiresAt.Unix(),
+	}, "创建成功", c)
+}
+
+// UploadFileByScanToken 使用一次性扫码凭证上传文件
+// @Tags      ExaFileUploadAndDownload
+// @Summary   使用扫码上传凭证上传文件
+// @accept    multipart/form-data
+// @Produce   application/json
+// @Param     x-upload-token  header    string  true  "扫码上传凭证"
+// @Param     file            formData  file    true  "上传文件"
+// @Success   200             {object}  response.Response{data=exampleRes.ExaFileResponse,msg=string}
+// @Router    /fileUploadAndDownload/uploadByScanToken [post]
+func (b *FileUploadAndDownloadApi) UploadFileByScanToken(c *gin.Context) {
+	classID, err := fileUploadAndDownloadService.ConsumeScanUploadToken(c.GetHeader("x-upload-token"))
+	if err != nil {
+		if !errors.Is(err, exampleService.ErrInvalidScanUploadToken) {
+			global.GVA_LOG.Error("读取扫码上传凭证失败!", zap.Error(err))
+		}
+		response.NoAuth("扫码上传凭证无效或已过期，请重新扫码", c)
+		return
+	}
+	b.uploadFile(c, classID)
+}
 
 // UploadFile
 // @Tags      ExaFileUploadAndDownload
@@ -23,10 +76,14 @@ type FileUploadAndDownloadApi struct{}
 // @Success   200   {object}  response.Response{data=exampleRes.ExaFileResponse,msg=string}  "上传文件示例,返回包括文件详情"
 // @Router    /fileUploadAndDownload/upload [post]
 func (b *FileUploadAndDownloadApi) UploadFile(c *gin.Context) {
+	classId, _ := strconv.Atoi(c.DefaultPostForm("classId", "0"))
+	b.uploadFile(c, classId)
+}
+
+func (b *FileUploadAndDownloadApi) uploadFile(c *gin.Context, classId int) {
 	var file example.ExaFileUploadAndDownload
 	noSave := c.DefaultQuery("noSave", "0")
 	_, header, err := c.Request.FormFile("file")
-	classId, _ := strconv.Atoi(c.DefaultPostForm("classId", "0"))
 	if err != nil {
 		global.GVA_LOG.Error("接收文件失败!", zap.Error(err))
 		response.FailWithMessage("接收文件失败", c)

--- a/server/initialize/router.go
+++ b/server/initialize/router.go
@@ -97,8 +97,12 @@ func Routers() *gin.Engine {
 		systemRouter.InitLoginLogRouter(PrivateGroup)                       // 登录日志
 		systemRouter.InitApiTokenRouter(PrivateGroup)                       // apiToken签发
 		exampleRouter.InitCustomerRouter(PrivateGroup)                      // 客户路由
-		exampleRouter.InitFileUploadAndDownloadRouter(PrivateGroup)         // 文件上传下载功能路由
 		exampleRouter.InitAttachmentCategoryRouterRouter(PrivateGroup)      // 文件上传下载分类
+		// 文件上传下载功能路由
+		exampleRouter.InitFileUploadAndDownloadRouter(
+			PrivateGroup,
+			PublicGroup,
+		)
 	}
 
 	//插件路由安装

--- a/server/model/system/request/sys_casbin.go
+++ b/server/model/system/request/sys_casbin.go
@@ -22,6 +22,7 @@ func DefaultCasbin() []CasbinInfo {
 		{Path: "/user/getUserInfo", Method: "GET"},
 		{Path: "/user/setSelfInfo", Method: "PUT"},
 		{Path: "/fileUploadAndDownload/upload", Method: "POST"},
+		{Path: "/fileUploadAndDownload/createScanUploadToken", Method: "POST"},
 		{Path: "/sysDictionary/findSysDictionary", Method: "GET"},
 	}
 }

--- a/server/router/example/exa_file_upload_and_download.go
+++ b/server/router/example/exa_file_upload_and_download.go
@@ -6,10 +6,12 @@ import (
 
 type FileUploadAndDownloadRouter struct{}
 
-func (e *FileUploadAndDownloadRouter) InitFileUploadAndDownloadRouter(Router *gin.RouterGroup) {
-	fileUploadAndDownloadRouter := Router.Group("fileUploadAndDownload")
+func (e *FileUploadAndDownloadRouter) InitFileUploadAndDownloadRouter(PrivateRouter *gin.RouterGroup, PublicRouter *gin.RouterGroup) {
+	fileUploadAndDownloadRouter := PrivateRouter.Group("fileUploadAndDownload")
+	scanUploadRouter := PublicRouter.Group("fileUploadAndDownload")
 	{
 		fileUploadAndDownloadRouter.POST("upload", exaFileUploadAndDownloadApi.UploadFile)                                 // 上传文件
+		fileUploadAndDownloadRouter.POST("createScanUploadToken", exaFileUploadAndDownloadApi.CreateScanUploadToken)       // 创建扫码上传凭证
 		fileUploadAndDownloadRouter.POST("getFileList", exaFileUploadAndDownloadApi.GetFileList)                           // 获取上传文件列表
 		fileUploadAndDownloadRouter.POST("deleteFile", exaFileUploadAndDownloadApi.DeleteFile)                             // 删除指定文件
 		fileUploadAndDownloadRouter.POST("editFileName", exaFileUploadAndDownloadApi.EditFileName)                         // 编辑文件名或者备注
@@ -18,5 +20,8 @@ func (e *FileUploadAndDownloadRouter) InitFileUploadAndDownloadRouter(Router *gi
 		fileUploadAndDownloadRouter.POST("breakpointContinueFinish", exaFileUploadAndDownloadApi.BreakpointContinueFinish) // 切片传输完成
 		fileUploadAndDownloadRouter.POST("removeChunk", exaFileUploadAndDownloadApi.RemoveChunk)                           // 删除切片
 		fileUploadAndDownloadRouter.POST("importURL", exaFileUploadAndDownloadApi.ImportURL)                               // 导入URL
+	}
+	{
+		scanUploadRouter.POST("uploadByScanToken", exaFileUploadAndDownloadApi.UploadFileByScanToken) // 使用一次性凭证扫码上传
 	}
 }

--- a/server/service/example/scan_upload_token.go
+++ b/server/service/example/scan_upload_token.go
@@ -1,0 +1,146 @@
+package example
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/flipped-aurora/gin-vue-admin/server/global"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	scanUploadTokenTTL    = 5 * time.Minute
+	scanUploadTokenPrefix = "scan-upload-token:"
+)
+
+var (
+	ErrInvalidScanUploadToken = errors.New("扫码上传凭证无效或已过期")
+	scanUploadTokens          = newScanUploadTokenStore()
+	consumeScanUploadToken    = redis.NewScript(`
+local value = redis.call("GET", KEYS[1])
+if value then
+  redis.call("DEL", KEYS[1])
+end
+return value
+`)
+)
+
+type scanUploadTokenEntry struct {
+	classID   int
+	expiresAt time.Time
+}
+
+type scanUploadTokenStore struct {
+	mu      sync.Mutex
+	entries map[string]scanUploadTokenEntry
+	now     func() time.Time
+}
+
+func newScanUploadTokenStore() *scanUploadTokenStore {
+	return &scanUploadTokenStore{
+		entries: make(map[string]scanUploadTokenEntry),
+		now:     time.Now,
+	}
+}
+
+func newScanUploadToken() (string, error) {
+	randomBytes := make([]byte, 32)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return "", fmt.Errorf("生成扫码上传凭证失败: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(randomBytes), nil
+}
+
+func (s *scanUploadTokenStore) issue(classID int) (string, time.Time, error) {
+	for {
+		token, err := newScanUploadToken()
+		if err != nil {
+			return "", time.Time{}, err
+		}
+		expiresAt := s.now().Add(scanUploadTokenTTL)
+
+		if global.GVA_CONFIG.System.UseRedis && global.GVA_REDIS != nil {
+			created, err := global.GVA_REDIS.SetNX(
+				context.Background(),
+				scanUploadTokenPrefix+token,
+				strconv.Itoa(classID),
+				scanUploadTokenTTL,
+			).Result()
+			if err != nil {
+				return "", time.Time{}, fmt.Errorf("保存扫码上传凭证失败: %w", err)
+			}
+			if created {
+				return token, expiresAt, nil
+			}
+			continue
+		}
+
+		s.mu.Lock()
+		s.removeExpiredLocked()
+		if _, exists := s.entries[token]; !exists {
+			s.entries[token] = scanUploadTokenEntry{classID: classID, expiresAt: expiresAt}
+			s.mu.Unlock()
+			return token, expiresAt, nil
+		}
+		s.mu.Unlock()
+	}
+}
+
+func (s *scanUploadTokenStore) consume(token string) (int, error) {
+	token = strings.TrimSpace(token)
+	if len(token) != 43 {
+		return 0, ErrInvalidScanUploadToken
+	}
+
+	if global.GVA_CONFIG.System.UseRedis && global.GVA_REDIS != nil {
+		classID, err := consumeScanUploadToken.Run(
+			context.Background(),
+			global.GVA_REDIS,
+			[]string{scanUploadTokenPrefix + token},
+		).Text()
+		if errors.Is(err, redis.Nil) {
+			return 0, ErrInvalidScanUploadToken
+		}
+		if err != nil {
+			return 0, fmt.Errorf("读取扫码上传凭证失败: %w", err)
+		}
+		parsedClassID, err := strconv.Atoi(classID)
+		if err != nil {
+			return 0, ErrInvalidScanUploadToken
+		}
+		return parsedClassID, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, exists := s.entries[token]
+	delete(s.entries, token)
+	if !exists || !s.now().Before(entry.expiresAt) {
+		return 0, ErrInvalidScanUploadToken
+	}
+	return entry.classID, nil
+}
+
+func (s *scanUploadTokenStore) removeExpiredLocked() {
+	now := s.now()
+	for token, entry := range s.entries {
+		if !now.Before(entry.expiresAt) {
+			delete(s.entries, token)
+		}
+	}
+}
+
+func (e *FileUploadAndDownloadService) IssueScanUploadToken(classID int) (string, time.Time, error) {
+	return scanUploadTokens.issue(classID)
+}
+
+func (e *FileUploadAndDownloadService) ConsumeScanUploadToken(token string) (int, error) {
+	return scanUploadTokens.consume(token)
+}

--- a/server/service/example/scan_upload_token_test.go
+++ b/server/service/example/scan_upload_token_test.go
@@ -1,0 +1,87 @@
+package example
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/flipped-aurora/gin-vue-admin/server/global"
+)
+
+func TestScanUploadTokenIsBoundAndOneTime(t *testing.T) {
+	originalUseRedis := global.GVA_CONFIG.System.UseRedis
+	defer func() { global.GVA_CONFIG.System.UseRedis = originalUseRedis }()
+	global.GVA_CONFIG.System.UseRedis = false
+	store := newScanUploadTokenStore()
+	now := time.Date(2026, time.July, 13, 0, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+
+	token, expiresAt, err := store.issue(42)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected a non-empty token")
+	}
+	if expiresAt.Sub(now) != scanUploadTokenTTL {
+		t.Fatalf("unexpected expiry: %v", expiresAt)
+	}
+
+	classID, err := store.consume(token)
+	if err != nil {
+		t.Fatalf("consume token: %v", err)
+	}
+	if classID != 42 {
+		t.Fatalf("expected class ID 42, got %d", classID)
+	}
+	if _, err = store.consume(token); !errors.Is(err, ErrInvalidScanUploadToken) {
+		t.Fatalf("expected token reuse to fail, got %v", err)
+	}
+}
+
+func TestScanUploadTokenExpires(t *testing.T) {
+	originalUseRedis := global.GVA_CONFIG.System.UseRedis
+	defer func() { global.GVA_CONFIG.System.UseRedis = originalUseRedis }()
+	global.GVA_CONFIG.System.UseRedis = false
+	store := newScanUploadTokenStore()
+	now := time.Date(2026, time.July, 13, 0, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+
+	token, _, err := store.issue(7)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	now = now.Add(scanUploadTokenTTL)
+	if _, err = store.consume(token); !errors.Is(err, ErrInvalidScanUploadToken) {
+		t.Fatalf("expected expired token to fail, got %v", err)
+	}
+}
+
+func TestScanUploadTokenConcurrentConsumeSucceedsOnce(t *testing.T) {
+	originalUseRedis := global.GVA_CONFIG.System.UseRedis
+	defer func() { global.GVA_CONFIG.System.UseRedis = originalUseRedis }()
+	global.GVA_CONFIG.System.UseRedis = false
+	store := newScanUploadTokenStore()
+	token, _, err := store.issue(9)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+
+	var successes atomic.Int32
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if classID, consumeErr := store.consume(token); consumeErr == nil && classID == 9 {
+				successes.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	if successes.Load() != 1 {
+		t.Fatalf("expected exactly one successful consume, got %d", successes.Load())
+	}
+}

--- a/server/source/system/api.go
+++ b/server/source/system/api.go
@@ -111,6 +111,8 @@ func (i *initApi) InitializeData(ctx context.Context) (context.Context, error) {
 		{ApiGroup: "分片上传", Method: "POST", Path: "/fileUploadAndDownload/removeChunk", Description: "上传完成移除文件"},
 
 		{ApiGroup: "文件上传与下载", Method: "POST", Path: "/fileUploadAndDownload/upload", Description: "文件上传（建议选择）"},
+		{ApiGroup: "文件上传与下载", Method: "POST", Path: "/fileUploadAndDownload/createScanUploadToken", Description: "创建扫码上传凭证"},
+		{ApiGroup: "文件上传与下载", Method: "POST", Path: "/fileUploadAndDownload/uploadByScanToken", Description: "使用扫码凭证上传文件"},
 		{ApiGroup: "文件上传与下载", Method: "POST", Path: "/fileUploadAndDownload/deleteFile", Description: "删除文件"},
 		{ApiGroup: "文件上传与下载", Method: "POST", Path: "/fileUploadAndDownload/editFileName", Description: "文件名或者备注编辑"},
 		{ApiGroup: "文件上传与下载", Method: "POST", Path: "/fileUploadAndDownload/getFileList", Description: "获取上传文件列表"},

--- a/server/source/system/casbin.go
+++ b/server/source/system/casbin.go
@@ -108,6 +108,7 @@ func (i *initCasbin) InitializeData(ctx context.Context) (context.Context, error
 		{Ptype: "p", V0: "888", V1: "/fileUploadAndDownload/removeChunk", V2: "POST"},
 
 		{Ptype: "p", V0: "888", V1: "/fileUploadAndDownload/upload", V2: "POST"},
+		{Ptype: "p", V0: "888", V1: "/fileUploadAndDownload/createScanUploadToken", V2: "POST"},
 		{Ptype: "p", V0: "888", V1: "/fileUploadAndDownload/deleteFile", V2: "POST"},
 		{Ptype: "p", V0: "888", V1: "/fileUploadAndDownload/editFileName", V2: "POST"},
 		{Ptype: "p", V0: "888", V1: "/fileUploadAndDownload/getFileList", V2: "POST"},
@@ -292,6 +293,7 @@ func (i *initCasbin) InitializeData(ctx context.Context) (context.Context, error
 		{Ptype: "p", V0: "8881", V1: "/user/getUserList", V2: "POST"},
 		{Ptype: "p", V0: "8881", V1: "/user/setUserAuthority", V2: "POST"},
 		{Ptype: "p", V0: "8881", V1: "/fileUploadAndDownload/upload", V2: "POST"},
+		{Ptype: "p", V0: "8881", V1: "/fileUploadAndDownload/createScanUploadToken", V2: "POST"},
 		{Ptype: "p", V0: "8881", V1: "/fileUploadAndDownload/getFileList", V2: "POST"},
 		{Ptype: "p", V0: "8881", V1: "/fileUploadAndDownload/deleteFile", V2: "POST"},
 		{Ptype: "p", V0: "8881", V1: "/fileUploadAndDownload/editFileName", V2: "POST"},
@@ -340,6 +342,7 @@ func (i *initCasbin) InitializeData(ctx context.Context) (context.Context, error
 		{Ptype: "p", V0: "9528", V1: "/user/getUserList", V2: "POST"},
 		{Ptype: "p", V0: "9528", V1: "/user/setUserAuthority", V2: "POST"},
 		{Ptype: "p", V0: "9528", V1: "/fileUploadAndDownload/upload", V2: "POST"},
+		{Ptype: "p", V0: "9528", V1: "/fileUploadAndDownload/createScanUploadToken", V2: "POST"},
 		{Ptype: "p", V0: "9528", V1: "/fileUploadAndDownload/getFileList", V2: "POST"},
 		{Ptype: "p", V0: "9528", V1: "/fileUploadAndDownload/deleteFile", V2: "POST"},
 		{Ptype: "p", V0: "9528", V1: "/fileUploadAndDownload/editFileName", V2: "POST"},

--- a/web/src/api/fileUploadAndDownload.js
+++ b/web/src/api/fileUploadAndDownload.js
@@ -65,3 +65,12 @@ export const uploadFile = (data) => {
     data,
   });
 };
+
+// 创建短时、一次性且绑定上传分类的扫码凭证
+export const createScanUploadToken = (classId) => {
+  return service({
+    url: '/fileUploadAndDownload/createScanUploadToken',
+    method: 'post',
+    data: { classId }
+  })
+}

--- a/web/src/components/upload/QR-code.vue
+++ b/web/src/components/upload/QR-code.vue
@@ -31,7 +31,7 @@
 import logoSrc from '@/assets/logo.png'
 import vueQr from 'vue-qr/src/packages/vue-qr.vue'
 import { ref } from 'vue'
-import { useUserStore } from '@/pinia/modules/user'
+import { createScanUploadToken } from '@/api/fileUploadAndDownload'
 
 defineOptions({
   name: 'QRCodeUpload'
@@ -47,14 +47,15 @@ const props = defineProps({
 })
 
 const dialogVisible = ref(false)
-const userStore = useUserStore()
 const codeUrl = ref('')
 
-const createQrCode = () => {
+const createQrCode = async() => {
+  const res = await createScanUploadToken(props.classId)
+  if (res.code !== 0) return
   const local = window.location
-  codeUrl.value = local.protocol + '//' + local.host + '/#/scanUpload?id=' + props.classId + '&token=' + userStore.token + '&t=' + Date.now()
+  const query = new URLSearchParams({ uploadToken: res.data.token })
+  codeUrl.value = `${local.protocol}//${local.host}/#/scanUpload?${query.toString()}`
   dialogVisible.value = true
-  console.log(codeUrl.value)
 }
 
 const onFinished = () => {

--- a/web/src/view/example/upload/scanUpload.vue
+++ b/web/src/view/example/upload/scanUpload.vue
@@ -3,13 +3,13 @@
     <el-upload
         ref="uploadRef"
         class="h5-uploader"
-        :action="`${getBaseUrl()}/fileUploadAndDownload/upload`"
+        :action="`${getBaseUrl()}/fileUploadAndDownload/uploadByScanToken`"
         accept="image/*"
         :show-file-list="false"
         :auto-upload="false"
-        :headers="{ 'x-token': token }"
-        :data="{'classId': classId}"
+        :headers="{ 'x-upload-token': uploadToken }"
         :on-success="handleImageSuccess"
+        :on-error="handleImageError"
         :on-change="handleFileChange"
     >
       <el-icon class="h5-uploader-icon"><Plus /></el-icon>
@@ -84,14 +84,12 @@ import 'vue-cropper/dist/index.css'
 import { VueCropper } from 'vue-cropper'
 import { getBaseUrl } from '@/utils/format'
 import { useRouter } from 'vue-router'
-import { useUserStore } from "@/pinia";
 
 defineOptions({
   name: 'scanUpload'
 })
 
-const classId = ref(0)
-const token = ref('')
+const uploadToken = ref('')
 const isCrop = ref(false)
 
 const windowWidth = ref(300)
@@ -109,10 +107,11 @@ onMounted(() => {
 
 const router = useRouter()
 router.isReady().then(() => {
-  let query = router.currentRoute.value.query
-  //console.log(query)
-  classId.value = query.id
-  token.value = query.token
+  const query = router.currentRoute.value.query
+  uploadToken.value = query.uploadToken || ''
+  if (uploadToken.value) {
+    router.replace({ path: '/scanUpload' })
+  }
 }).catch((err) => {
   console.log(err)
 })
@@ -194,13 +193,22 @@ const handleUpload = () => {
 }
 
 const handleImageSuccess = (res) => {
+  uploading.value = false
+  if (res.code !== 0) {
+    ElMessage.error(res.msg || '上传失败，请重新扫码')
+    return
+  }
   const { data } = res
   if (data) {
     imgSrc.value = null
-    uploading.value = false
     previews.value = {}
     ElMessage.success('上传成功')
   }
+}
+
+const handleImageError = () => {
+  uploading.value = false
+  ElMessage.error('上传凭证无效或已过期，请重新扫码')
 }
 
 </script>


### PR DESCRIPTION
## What changed

- Stop embedding the current user's full login JWT in scan-upload QR codes.
- Add a dedicated 256-bit random scan-upload credential with a five-minute TTL.
- Consume the credential atomically on the first upload attempt and bind the server-side record to the selected `classId`.
- Restrict the public scan endpoint to file upload only; it does not accept or parse login JWTs and ignores client-supplied category IDs.
- Use Redis `SETNX` plus an atomic Lua consume when Redis is enabled, with a locked in-process store for the default non-Redis setup.
- Remove the short-lived credential from the browser URL after the scan page captures it.
- Add API/Casbin initialization data so credential issuance follows the existing upload permission.

## Why

The previous QR URL contained the user's complete login JWT. Anyone who saw or retained the QR code could reuse that JWT against any API available to the account for the token's full lifetime. The new credential is short-lived, one-time, upload-only, and bound to one server-controlled file category.

## Validation

- `go test -race ./service/example`
- `go test ./api/v1/example ./router/example ./initialize ./source/system ./model/system/request`
- `npm run build`
- `go run github.com/swaggo/swag/cmd/swag@v1.16.4 init` (annotations parse successfully; generated docs were not committed because the repository's checked-in docs are already stale and regeneration creates a large unrelated diff)

`go test ./...` was also attempted. It reaches and passes the changed service package, but the repository-wide run is currently blocked by pre-existing failures outside this diff: a misplaced compiler directive in `plugin/announcement/gen`, non-constant format strings in existing tests, and missing `plugin/gva` AST test fixtures.
