### PR TITLE
ci: pin ad-m/github-push-action to a full commit SHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add . && git commit -m "release: v${GVA_VERSION##v}"
       - name: Push
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}


### PR DESCRIPTION
## What

Pin `ad-m/github-push-action` in `.github/workflows/ci.yaml` to a full commit SHA instead of the mutable `@master` branch.

```diff
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
```

## Why

In the `release-pr` job, this third-party action is handed `github_token: ${{ secrets.GITHUB_TOKEN }}` and pushes a commit to the repository. Because it is referenced by the moving `@master` branch, the exact code that runs with that token can change at any time without any change in this repository — the well-known third-party-action supply-chain risk that GitHub's own hardening guidance addresses by recommending a full-length commit SHA.

I want to be upfront about scope: this job only runs on `workflow_dispatch` and is additionally gated by `github.repository_owner == 'flipped-aurora'`, so an outside contributor cannot trigger it. This is a hardening/defence-in-depth change, not a response to an active exploit.

## Behaviour

`881a6320fdb16eb5318c5054f31c218aec2b324c` is the commit that `@master` resolves to today, and it is also tagged **v1.3.0**. So this pins to exactly what already runs — nothing about the current behaviour changes. The trailing `# v1.3.0` comment keeps the human-readable version visible for future bumps.

## Notes

I used AI assistance to help review the workflow and draft this change; I read and verified every line myself, and I take responsibility for it. Thank you for maintaining gin-vue-admin — happy to adjust or close if this isn't a direction you want.
