### PR TITLE
casbin_util.go: correct Enforcer cache expiration to 1 hour

### DIFF
--- a/server/utils/casbin_util.go
+++ b/server/utils/casbin_util.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"sync"
+	"time"
 
 	"github.com/casbin/casbin/v3"
 	"github.com/casbin/casbin/v3/model"
@@ -49,7 +50,7 @@ func GetCasbin() *casbin.SyncedCachedEnforcer {
 			zap.L().Error("casbin enforcer 初始化失败", zap.Error(err))
 			return
 		}
-		enforcer.SetExpireTime(60 * 60)
+		enforcer.SetExpireTime(time.Hour)
 		if err = enforcer.LoadPolicy(); err != nil {
 			zap.L().Error("casbin 策略加载失败", zap.Error(err))
 			return


### PR DESCRIPTION
Previously set to 60*60, which is 3600 nanoseconds, causing the cache to expire immediately. Change to time.Hour to properly cache policies for 1 hour.