### PR TITLE
fix: 代码生成器连续生成时「生成后端」复选框失效导致只生成前端代码

### DIFF
--- a/web/src/view/systemTools/autoCode/index.vue
+++ b/web/src/view/systemTools/autoCode/index.vue
@@ -1586,6 +1586,8 @@
       autoCreateResource: false,
       onlyTemplate: false,
       isTree: false,
+      generateWeb: true,
+      generateServer: true,
       treeJson: "",
       fields: []
     }


### PR DESCRIPTION
## 关联 issue

Fixes #2252

## 问题描述

在「代码生成器」页面连续生成多个结构体时，第一次生成成功后，「生成后端」复选框会变成未勾选且无法再勾选（该复选框带有 `disabled` 属性），导致后续生成只输出前端代码（`web/src/...`），后端代码（`server/...`）整段被跳过。

## 复现步骤

1. 打开「代码生成器」，配置一个结构体（「生成前端」「生成后端」均勾选），点击「生成代码」。
2. 生成成功后，页面会调用 `clearCatch()` 重置表单。
3. 此时观察专家模式里的「生成后端」复选框：变成未勾选，且因带 `disabled` 无法手动勾回。
4. 再配置第二个结构体并点击「生成代码」：只会生成前端代码，后端 model/service/api/router 及注册（router_biz.go / gorm_biz.go）均不会生成。

## 根因

`clearCatch()` 在重置 `form.value` 时，遗漏了 `generateWeb` 和 `generateServer` 两个字段：

```js
const clearCatch = async () => {
  form.value = {
    // ... 其他字段
    onlyTemplate: false,
    isTree: false,
    treeJson: "",   // ← 这里直接跳到 treeJson，少了 generateWeb / generateServer
    fields: []
  }
  // ...
}
```

初始 `form` 定义里是有这两个字段的（`generateWeb: true, generateServer: true`），但 `clearCatch()` 重置时漏掉了。于是：

1. 第一次生成后，`form.value.generateServer` 变成 `undefined`；
2. `undefined` 在 `JSON.stringify` 时被省略，后端 Go 反序列化得到 `GenerateServer = false`；
3. 后端 `auto_code_package.go` 中 `if !info.GenerateServer && !isPackage { break }` 会把后端生成整个跳过；
4. 又因为「生成后端」复选框写了 `disabled`，用户无法手动勾回，问题延续到后续所有生成。

## 修复

在 `clearCatch()` 的重置对象里补上这两个字段，与初始定义保持一致：

```js
      onlyTemplate: false,
      isTree: false,
      generateWeb: true,
      generateServer: true,
      treeJson: "",
      fields: []
```
